### PR TITLE
Feature/1310 Block: Split Two Columns - update

### DIFF
--- a/classes/controller/blocks/class-p4bks-blocks-splittwocolumns-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-splittwocolumns-controller.php
@@ -29,16 +29,17 @@ if ( ! class_exists( 'P4BKS_Blocks_SplitTwoColumns_Controller' ) ) {
 			$issues = get_posts( [
 				'post_type'     => 'page',
 				'category_name' => 'issues',
+				'post_parent'   => 0,
 				'numberposts'   => -1,
 			] );
 
 			$options = [];
 			if ( $issues ) {
 				foreach ( $issues as $issue ) {
-					array_push( $options, [
+					$options[] = [
 						'value' => (string) $issue->ID,
 						'label' => get_the_title( $issue->ID ),
-					] );
+					];
 				}
 			}
 


### PR DESCRIPTION
Fixes issue with selecting also pages other than the Issue pages (e.g. Take Action pages which have as parent page the Issue page).