### PR TITLE
Get covers only for Take Action pages that have page ACT as parent. R…

### DIFF
--- a/classes/controller/blocks/class-p4bks-blocks-covers-controllers.php
+++ b/classes/controller/blocks/class-p4bks-blocks-covers-controllers.php
@@ -88,23 +88,23 @@ if ( ! class_exists( 'P4BKS_Blocks_Covers_Controller' ) ) {
 			$tag_id = absint( $fields['select_tag'] );
 
 			$args = [
-				'post_type'     => 'page',
-				'post_status'   => 'publish',
-				'order_by'      => 'date',
-				'order'         => 'DESC',
-				'numberposts'   => P4BKS_COVERS_NUM,
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_parent' => get_page_by_path( 'act', 'OBJECT', 'page' )->ID,
+				'orderby'     => 'post_date',
+				'order'       => 'DESC',
+				'numberposts' => P4BKS_COVERS_NUM,
 			];
 
-			// If we associated a tag with the covers to be displayed.
-			if( $tag_id ) {
+			// If user selected a tag to associate with the Take Action page covers.
+			if ( $tag_id ) {
 				$args['tag_id'] = $tag_id;
 			}
 
-			$actions = wp_get_recent_posts( $args, 'OBJECT' );
+			$actions = get_posts( $args );
 			$covers  = [];
 
 			if ( $actions ) {
-				$site_url          = get_site_url();
 				$cover_button_text = __( 'Take Action', 'planet4-blocks' );
 
 				foreach ( $actions as $action ) {
@@ -113,16 +113,16 @@ if ( ! class_exists( 'P4BKS_Blocks_Covers_Controller' ) ) {
 
 					if ( is_array( $wp_tags ) && $wp_tags ) {
 						foreach ( $wp_tags as $wp_tag ) {
-							array_push( $tags, [
+							$tags[] = [
 								'slug' => $wp_tag->slug,
 								'href' => get_tag_link( $wp_tag ),
-							]);
+							];
 						}
 					}
 					$covers[] = [
 						'tags'        => $tags,
 						'title'       => get_the_title( $action ),
-						'excerpt'     => get_the_excerpt( $action ),	// Note: WordPress removes shortcodes from auto-generated excerpts.
+						'excerpt'     => get_the_excerpt( $action ),    // Note: WordPress removes shortcodes from auto-generated excerpts.
 						'image'       => get_the_post_thumbnail_url( $action ),
 						'button_text' => $cover_button_text,
 						'button_link' => get_post_permalink( $action->ID ),


### PR DESCRIPTION
…eplace wp_get_recent_posts() with get_posts(). Use direct assignment for indexed array instead of array_push(). Remove unecessary get_site_url() call.