### PR TITLE
1413 Post edit screen preview for shortcake blocks

### DIFF
--- a/classes/controller/blocks/class-p4bks-blocks-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-controller.php
@@ -135,20 +135,20 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 
 			$request = add_query_arg(
 				array_merge( $fields,
-					[
+					array(
 						'_tag'     => $shortcode_tag,
 						'_content' => $content,
 						'_post_id' => get_the_ID(),
-						'_nonce'    => wp_create_nonce( 'p4bks_preview_render_' . $this->block_name ),
+						'_nonce'   => wp_create_nonce( 'p4bks_preview_render_' . $this->block_name ),
 						'action'   => 'p4bks_preview_render_' . $this->block_name
-					]
+					)
 				),
 				admin_url( 'admin-ajax.php' )
 			);
 
 			ob_start();
 			?>
-				<iframe width="100%" src="<?php echo esc_url( $request ) ?>" onload="this.style.height = this.contentWindow.document.body.scrollHeight + 'px';"></iframe>
+			<iframe width="100%" src="<?php echo esc_url( $request ) ?>" onload="this.style.height = this.contentWindow.document.body.scrollHeight + 'px';"></iframe>
 			<?php
 			return ob_get_clean();
 		}
@@ -160,6 +160,11 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 		 * via $this->prepare_template along with wrapper html and enqueued frontend styles and scripts
 		 */
 		public function prepare_admin_preview() {
+
+			// Shortcode UI not callable
+			if ( ! is_callable( 'Shortcode_UI', 'get_shortcode' ) ) {
+				exit;
+			}
 
 			$tag                 = sanitize_text_field( $_GET['_tag'] );
 			$content             = wp_kses_post( $_GET['content'] );
@@ -190,8 +195,8 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 				setup_postdata( $post );
 				// @codingStandardsIgnoreEnd
 			}
-			?>
 
+			?>
 			<html>
 				<head>
 					<?php do_action( 'wp_head' ); ?>

--- a/classes/controller/blocks/class-p4bks-blocks-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-controller.php
@@ -166,32 +166,33 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 				exit;
 			}
 
-			$tag                 = sanitize_text_field( $_GET['_tag'] );
-			$content             = wp_kses_post( $_GET['content'] );
-			$post_id             = isset( $_GET['_post_id'] ) && is_numeric( $_GET['_post_id'] ) ? absint( $_GET['_post_id'] ) : false;
-			$shortcode_object    = \Shortcode_UI::get_instance()->get_shortcode( $tag );
-			$shortcode_attrs     = is_array( $shortcode_object ) && is_array( $shortcode_object['attrs'] ) ? $shortcode_object['attrs'] : [];
-			$shortcode_attr_keys = wp_list_pluck( $shortcode_attrs, 'attr' );
-
 			// Don't do anything if an invalid nonce
 			if ( ! wp_verify_nonce( $_GET['_nonce'], 'p4bks_preview_render_' . $this->block_name ) ) {
 				exit;
 			}
 
-			$fields = [];
+			$tag                 = isset( $_GET['_tag'] ) ? sanitize_text_field( $_GET['_tag'] ) : '';
+			$content             = isset( $_GET['_content'] ) ? wp_kses_post( $_GET['_content'] ) : '';
+			$post_id             = isset( $_GET['_post_id'] ) && is_numeric( $_GET['_post_id'] ) ? absint( $_GET['_post_id'] ) : false;
+			$shortcode_object    = \Shortcode_UI::get_instance()->get_shortcode( $tag );
+			$shortcode_attrs     = is_array( $shortcode_object ) && is_array( $shortcode_object['attrs'] ) ? $shortcode_object['attrs'] : [];
+			$shortcode_attr_keys = wp_list_pluck( $shortcode_attrs, 'attr' );
+			$fields              = [];
 
 			// Filter out any $_GET params not used by the shortcode
 			foreach ( $shortcode_attr_keys as $attr_key ) {
-				if ( ! empty( $_GET[ $attr_key ] ) ) {
+				if ( isset( $_GET[ $attr_key ] ) ) {
 					$fields[ $attr_key ] = $_GET[ $attr_key ];
 				}
 			}
 
+			$current_post = get_post( $post_id );
+
 			// Setup postdata incase it's needed during shortcode render
-			if ( get_post( $post_id ) ) {
+			if ( $current_post ) {
 				// @codingStandardsIgnoreStart
 				global $post;
-				$post = get_post( $post_id );
+				$post = $current_post;
 				setup_postdata( $post );
 				// @codingStandardsIgnoreEnd
 			}

--- a/classes/controller/blocks/class-p4bks-blocks-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-controller.php
@@ -168,7 +168,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 
 			$tag                 = sanitize_text_field( $_GET['_tag'] );
 			$content             = wp_kses_post( $_GET['content'] );
-			$post_id             = isset( $_GET['post_id'] ) && is_numeric( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : false;
+			$post_id             = isset( $_GET['_post_id'] ) && is_numeric( $_GET['_post_id'] ) ? absint( $_GET['_post_id'] ) : false;
 			$shortcode_object    = \Shortcode_UI::get_instance()->get_shortcode( $tag );
 			$shortcode_attrs     = is_array( $shortcode_object ) && is_array( $shortcode_object['attrs'] ) ? $shortcode_object['attrs'] : [];
 			$shortcode_attr_keys = wp_list_pluck( $shortcode_attrs, 'attr' );

--- a/classes/controller/blocks/class-p4bks-blocks-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-controller.php
@@ -39,6 +39,9 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 			add_action( 'init', array( $this, 'shortcode_ui_register_shortcodes' ) );
 			// Add Two Column element in UI
 			add_action( 'register_shortcode_ui', array( $this, 'prepare_fields' ) );
+
+			// Register an admin render callback for previewing in the wysiwyg
+			add_action( 'wp_ajax_p4bks_preview_render_' . $this->block_name, array( $this, 'prepare_admin_preview' ) );
 		}
 
 		/**
@@ -85,8 +88,26 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 		 * @since 0.1.0
 		 */
 		public function shortcode_ui_register_shortcodes() {
-			// Define the callback for the advanced shortcode.
-			add_shortcode( 'shortcake_' . $this->block_name, array( $this, 'prepare_template' ) );
+
+			/**
+			 * If we're in a request to admin render shortcodes, use a preview iframe for render so we
+			 * can load in all the site styles.
+			 *
+			 * No clean filters/actions to check here so manually checking for ajax, action and user privs
+			 */
+			if (
+				wp_doing_ajax()
+				&& is_user_logged_in()
+				&& wp_get_current_user()->has_cap( 'edit_posts' )
+				&& isset( $_REQUEST['action'] )
+				&& $_REQUEST['action'] === 'bulk_do_shortcode'
+			) {
+				// Render a preview iframe using a wrapper method
+				add_shortcode( 'shortcake_' . $this->block_name, array( $this, 'prepare_template_preview_iframe' ) );
+			} else {
+				// Render using the default method
+				add_shortcode( 'shortcake_' . $this->block_name, array( $this, 'prepare_template' ) );
+			}
 		}
 
 		/**
@@ -99,6 +120,94 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 		 * @since 0.1.0
 		 */
 		abstract public function prepare_fields();
+
+		/**
+		 * Output markup of an iframe to render shortcode when previewing in admin edit screen.
+		 *
+		 * We need to load through iframe to enqueue frontend styles without breaking admin ui
+		 *
+		 * @param $fields
+		 * @param $content
+		 * @param $shortcode_tag
+		 * @return string
+		 */
+		public function prepare_template_preview_iframe( $fields, $content, $shortcode_tag ) {
+
+			$request = add_query_arg(
+				array_merge( $fields,
+					[
+						'_tag'     => $shortcode_tag,
+						'_content' => $content,
+						'_post_id' => get_the_ID(),
+						'_nonce'    => wp_create_nonce( 'p4bks_preview_render_' . $this->block_name ),
+						'action'   => 'p4bks_preview_render_' . $this->block_name
+					]
+				),
+				admin_url( 'admin-ajax.php' )
+			);
+
+			ob_start();
+			?>
+				<iframe width="100%" src="<?php echo esc_url( $request ) ?>" onload="this.style.height = this.contentWindow.document.body.scrollHeight + 'px';"></iframe>
+			<?php
+			return ob_get_clean();
+		}
+
+		/**
+		 * Render preview markup for the shortcode when loading through an iframe
+		 *
+		 * Takes a custom admin ajax request to render a shortcode and outputs shortcode
+		 * via $this->prepare_template along with wrapper html and enqueued frontend styles and scripts
+		 */
+		public function prepare_admin_preview() {
+
+			$tag                 = sanitize_text_field( $_GET['_tag'] );
+			$content             = wp_kses_post( $_GET['content'] );
+			$post_id             = isset( $_GET['post_id'] ) && is_numeric( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : false;
+			$shortcode_object    = \Shortcode_UI::get_instance()->get_shortcode( $tag );
+			$shortcode_attrs     = is_array( $shortcode_object ) && is_array( $shortcode_object['attrs'] ) ? $shortcode_object['attrs'] : [];
+			$shortcode_attr_keys = wp_list_pluck( $shortcode_attrs, 'attr' );
+
+			// Don't do anything if an invalid nonce
+			if ( ! wp_verify_nonce( $_GET['_nonce'], 'p4bks_preview_render_' . $this->block_name ) ) {
+				exit;
+			}
+
+			$fields = [];
+
+			// Filter out any $_GET params not used by the shortcode
+			foreach ( $shortcode_attr_keys as $attr_key ) {
+				if ( ! empty( $_GET[ $attr_key ] ) ) {
+					$fields[ $attr_key ] = $_GET[ $attr_key ];
+				}
+			}
+
+			// Setup postdata incase it's needed during shortcode render
+			if ( get_post( $post_id ) ) {
+				// @codingStandardsIgnoreStart
+				global $post;
+				$post = get_post( $post_id );
+				setup_postdata( $post );
+				// @codingStandardsIgnoreEnd
+			}
+			?>
+
+			<html>
+				<head>
+					<?php do_action( 'wp_head' ); ?>
+				</head>
+				<body style="background-color: transparent;">
+					<?php echo $this->prepare_template( $fields, $content, $tag ); ?>
+				</body>
+				<footer>
+					<?php do_action( 'wp_footer' ); ?>
+				</footer>
+			</html>
+			<?php
+
+			// Ajax callbacks need to call exit
+			exit;
+		}
 
 		/**
 		 * Callback for the shortcode.


### PR DESCRIPTION
- Adds a conditional to P4BKS_Blocks_Controller shortcode registration so we can render differently on preview
- Adds an iframe render method to render the shortcode via iframe in markup
- Adds a iframe ajax callback to render the markup defined by the preview iframe with html wrapper markup + site frontend scripts and styles

This is pretty hacky but looks to me like the best way to drop in the admin preview capability without either generating new admin script and style sheets specifically for these previews or having to modify existing functionality in the each registered block's prepare_template method.

see https://jira.greenpeace.org/browse/PLANET-1413

**Before**

<img width="1474" alt="screen shot 2017-10-30 at 16 07 59" src="https://user-images.githubusercontent.com/907521/32182299-356d8a66-bd8e-11e7-8186-b7d7807813b6.png">


**After**
<img width="1468" alt="screen shot 2017-10-30 at 16 07 15" src="https://user-images.githubusercontent.com/907521/32182304-3a0f4906-bd8e-11e7-8790-6b7c8709aa7c.png">

Will require some continued work/testing during development of these modules and frontend styling to give good compatibility