### PR TITLE
Deprecate Controller's protected  property and replace it with a cons…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This WordPress plugin provides the necessary blocks to be used with Shortcake UI
 2. Implement its parent's class two abstract methods. In method **prepare_fields()** you need to define the blocks fields and in method **prepare_template()** you need to prepare them for rendering.
 
 3. Create the template file that will be used to render your block inside directory _includes/blocks_. If the name of the file is **block_name**.twig then
-you need to override method load() and set the inherited property inside like this **$this->block_name = 'block_name'** It also works with html templates. Just add 'php' as the 3rd argument of the block() method.
+you need to set the BLOCK_NAME constant as **'block_name'** It also works with html templates. Just add 'php' as the 3rd argument of the block() method.
 
 4. Add your new class name to the array that the P4BKS_Loader function takes as an argument in the plugin's main file.
 

--- a/classes/controller/blocks/class-p4bks-blocks-articles-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-articles-controller.php
@@ -4,16 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_Articles_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_Articles_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_Articles_Controller extends P4BKS_Blocks_Controller {
 
-
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'articles';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'articles';
 
 		/**
 		 * Shortcode UI setup for the article shortcode.
@@ -49,7 +48,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Articles_Controller' ) ) {
 				'attrs'         => $fields,
 			);
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -126,7 +125,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Articles_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-campaignthumbnail-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-campaignthumbnail-controller.php
@@ -4,16 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_CampaignThumbnail_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_CampaignThumbnail_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_CampaignThumbnail_Controller extends P4BKS_Blocks_Controller {
 
-
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'campaign_thumbnail';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'campaign_thumbnail';
 
 		/**
 		 * Shortcode UI setup for the CampaignThumbnail shortcode.
@@ -41,7 +40,7 @@ if ( ! class_exists( 'P4BKS_Blocks_CampaignThumbnail_Controller' ) ) {
 				'attrs'         => $fields,
 			);
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -97,7 +96,7 @@ if ( ! class_exists( 'P4BKS_Blocks_CampaignThumbnail_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-carousel-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-carousel-controller.php
@@ -4,7 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_Carousel_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_Carousel_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_Carousel_Controller extends P4BKS_Blocks_Controller {
+
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'carousel';
 
 		/**
 		 * Override this method in order to give your block its own name.
@@ -12,7 +20,6 @@ if ( ! class_exists( 'P4BKS_Blocks_Carousel_Controller' ) ) {
 		public function load() {
 			add_filter( 'attachment_fields_to_edit', array( $this, 'add_image_attachment_fields_to_edit' ), null, 2 );
 			add_filter( 'attachment_fields_to_save', array( $this, 'add_image_attachment_fields_to_save' ), null, 2 );
-			$this->block_name = 'carousel';
 			parent::load();
 		}
 
@@ -86,7 +93,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Carousel_Controller' ) ) {
 				'attrs'         => $fields,
 			);
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -129,7 +136,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Carousel_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-carouselheader-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-carouselheader-controller.php
@@ -11,13 +11,8 @@ if ( ! class_exists( 'P4BKS_Blocks_CarouselHeader_Controller' ) ) {
 	 */
 	class P4BKS_Blocks_CarouselHeader_Controller extends P4BKS_Blocks_Controller {
 
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'carousel_header';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'carousel_header';
 
 		/**
 		 * Shortcode UI setup for carousel header shortcode.
@@ -106,7 +101,7 @@ if ( ! class_exists( 'P4BKS_Blocks_CarouselHeader_Controller' ) ) {
 				'attrs'         => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -148,7 +143,7 @@ if ( ! class_exists( 'P4BKS_Blocks_CarouselHeader_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $block_data );
+			$this->view->block( self::BLOCK_NAME, $block_data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-carouselsplit-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-carouselsplit-controller.php
@@ -11,14 +11,8 @@ if ( ! class_exists( 'P4BKS_Blocks_CarouselSplit_Controller' ) ) {
 	 */
 	class P4BKS_Blocks_CarouselSplit_Controller extends P4BKS_Blocks_Controller {
 
-
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'carousel_split';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'carousel_split';
 
 		/**
 		 * Shortcode UI setup for the carousel split shortcode.
@@ -49,7 +43,7 @@ if ( ! class_exists( 'P4BKS_Blocks_CarouselSplit_Controller' ) ) {
 				'attrs'         => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -89,7 +83,7 @@ if ( ! class_exists( 'P4BKS_Blocks_CarouselSplit_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $block_data );
+			$this->view->block( self::BLOCK_NAME, $block_data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-contentfourcolumn-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-contentfourcolumn-controller.php
@@ -11,13 +11,8 @@ if ( ! class_exists( 'P4BKS_Blocks_ContentFourColumn_Controller' ) ) {
 	 */
 	class P4BKS_Blocks_ContentFourColumn_Controller extends P4BKS_Blocks_Controller {
 
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'content_four_column';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'content_four_column';
 
 		/**
 		 * Shortcode UI setup for content four column shortcode.
@@ -47,7 +42,7 @@ if ( ! class_exists( 'P4BKS_Blocks_ContentFourColumn_Controller' ) ) {
 				'attrs'         => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -101,7 +96,7 @@ if ( ! class_exists( 'P4BKS_Blocks_ContentFourColumn_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $block_data );
+			$this->view->block( self::BLOCK_NAME, $block_data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-contentthreecolumn-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-contentthreecolumn-controller.php
@@ -4,16 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_ContentThreeColumn_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_ContentThreeColumn_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_ContentThreeColumn_Controller extends P4BKS_Blocks_Controller {
 
-
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'content_three_column';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'content_three_column';
 
 		/**
 		 * Shortcode UI setup for the ThreeColumn shortcode.
@@ -73,7 +72,7 @@ if ( ! class_exists( 'P4BKS_Blocks_ContentThreeColumn_Controller' ) ) {
 				'attrs'         => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -105,7 +104,7 @@ if ( ! class_exists( 'P4BKS_Blocks_ContentThreeColumn_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-controller.php
@@ -8,9 +8,22 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 
 	/**
 	 * Class P4BKS_Blocks_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
 	 */
 	abstract class P4BKS_Blocks_Controller {
 
+		/** @const string BLOCK_NAME
+		 * The block's name.
+		 */
+		const BLOCK_NAME = 'default';
+
+		/** @var string $block_name
+		 * This property is replaced with the use of a const and Late Static Binding http://php.net/manual/en/language.oop5.late-static-bindings.php.
+		 * Should be removed completely in following changes.
+		 *
+		 * @deprecated This property is no longer needed. This also results in children controllers not needing to override the load() method.
+		 */
 		protected $block_name = 'default';
 
 		/** @var P4BKS_View $view */
@@ -21,27 +34,28 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 		 * Avoid putting hooks inside the constructor, to make testing easier.
 		 *
 		 * @param P4BKS_View $view The view object.
-         *
-         * @since 0.1.0
+		 *
+		 * @since 0.1.0
 		 */
 		public function __construct( P4BKS_View $view ) {
 			$this->view = $view;
 		}
 
 		/**
+		 * Hooks all the needed functions to load the block.
 		 *
-         * @since 0.1.0
+		 * @since 0.1.0
 		 */
 		public function load() {
 			// Check to see if Shortcake is running, with an admin notice if not.
 			add_action( 'init', array( $this, 'shortcode_ui_detection' ) );
 			// Register the shortcodes.
 			add_action( 'init', array( $this, 'shortcode_ui_register_shortcodes' ) );
-			// Add Two Column element in UI
+			// Add Two Column element in UI.
 			add_action( 'register_shortcode_ui', array( $this, 'prepare_fields' ) );
 
-			// Register an admin render callback for previewing in the wysiwyg
-			add_action( 'wp_ajax_p4bks_preview_render_' . $this->block_name, array( $this, 'prepare_admin_preview' ) );
+			// Register an admin render callback for previewing in the wysiwyg.
+			add_action( 'wp_ajax_p4bks_preview_render_' . static::BLOCK_NAME, array( $this, 'prepare_admin_preview' ) );
 		}
 
 		/**
@@ -102,11 +116,11 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 				&& isset( $_REQUEST['action'] )
 				&& $_REQUEST['action'] === 'bulk_do_shortcode'
 			) {
-				// Render a preview iframe using a wrapper method
-				add_shortcode( 'shortcake_' . $this->block_name, array( $this, 'prepare_template_preview_iframe' ) );
+				// Render a preview iframe using a wrapper method.
+				add_shortcode( 'shortcake_' . static::BLOCK_NAME, array( $this, 'prepare_template_preview_iframe' ) );
 			} else {
-				// Render using the default method
-				add_shortcode( 'shortcake_' . $this->block_name, array( $this, 'prepare_template' ) );
+				// Render using the default method.
+				add_shortcode( 'shortcake_' . static::BLOCK_NAME, array( $this, 'prepare_template' ) );
 			}
 		}
 
@@ -126,10 +140,10 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 		 *
 		 * We need to load through iframe to enqueue frontend styles without breaking admin ui
 		 *
-		 * @param array $fields          Associative array of shortcode paramaters
-		 * @param string $content        The content of the shortcode block for content wrapper shortcodes only
-		 * @param string $shortcode_tag  The name of the shortcode
-		 * @return string                The html markup for the shortcode preview iframe
+		 * @param array  $fields         Associative array of shortcode paramaters.
+		 * @param string $content        The content of the shortcode block for content wrapper shortcodes only.
+		 * @param string $shortcode_tag  The name of the shortcode.
+		 * @return string                The html markup for the shortcode preview iframe.
 		 */
 		public function prepare_template_preview_iframe( $fields, $content, $shortcode_tag ) {
 
@@ -139,8 +153,8 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 						'_tag'     => $shortcode_tag,
 						'_content' => $content,
 						'_post_id' => get_the_ID(),
-						'_nonce'   => wp_create_nonce( 'p4bks_preview_render_' . $this->block_name ),
-						'action'   => 'p4bks_preview_render_' . $this->block_name,
+						'_nonce'   => wp_create_nonce( 'p4bks_preview_render_' . static::BLOCK_NAME ),
+						'action'   => 'p4bks_preview_render_' . static::BLOCK_NAME,
 					]
 				),
 				admin_url( 'admin-ajax.php' )
@@ -154,20 +168,20 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 		}
 
 		/**
-		 * Render preview markup for the shortcode when loading through an iframe
+		 * Render preview markup for the shortcode when loading through an iframe.
 		 *
 		 * Takes a custom admin ajax request to render a shortcode and outputs shortcode
-		 * via $this->prepare_template along with wrapper html and enqueued frontend styles and scripts
+		 * via $this->prepare_template along with wrapper html and enqueued frontend styles and scripts.
 		 */
 		public function prepare_admin_preview() {
 
-			// Shortcode UI not callable
+			// Shortcode UI not callable.
 			if ( ! is_callable( 'Shortcode_UI', 'get_shortcode' ) ) {
 				exit;
 			}
 
-			// Don't do anything if an invalid nonce
-			if ( ! wp_verify_nonce( $_GET['_nonce'], 'p4bks_preview_render_' . $this->block_name ) ) {
+			// Don't do anything if an invalid nonce.
+			if ( ! wp_verify_nonce( $_GET['_nonce'], 'p4bks_preview_render_' . static::BLOCK_NAME ) ) {
 				exit;
 			}
 
@@ -179,7 +193,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 			$shortcode_attr_keys = wp_list_pluck( $shortcode_attrs, 'attr' );
 			$fields              = [];
 
-			// Filter out any $_GET params not used by the shortcode
+			// Filter out any $_GET params not used by the shortcode.
 			foreach ( $shortcode_attr_keys as $attr_key ) {
 				if ( isset( $_GET[ $attr_key ] ) ) {
 					$fields[ $attr_key ] = $_GET[ $attr_key ];
@@ -188,7 +202,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 
 			$current_post = get_post( $post_id );
 
-			// Setup postdata incase it's needed during shortcode render
+			// Setup postdata incase it's needed during shortcode render.
 			if ( $current_post ) {
 				// @codingStandardsIgnoreStart
 				global $post;
@@ -211,7 +225,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 			</html>
 			<?php
 
-			// Ajax callbacks need to call exit
+			// Ajax callbacks need to call exit.
 			exit;
 		}
 
@@ -219,10 +233,9 @@ if ( ! class_exists( 'P4BKS_Blocks_Controller' ) ) {
 		 * Callback for the shortcode.
 		 * It renders the shortcode based on supplied attributes.
 		 *
-		 *
-		 * @param array $fields          Associative array of shortcode paramaters
-		 * @param string $content        The content of the shortcode block for content wrapper shortcodes only
-		 * @param string $shortcode_tag  The name of the shortcode
+		 * @param array  $fields         Associative array of shortcode paramaters.
+		 * @param string $content        The content of the shortcode block for content wrapper shortcodes only.
+		 * @param string $shortcode_tag  The name of the shortcode.
 		 *
 		 * @since 0.1.0
 		 *

--- a/classes/controller/blocks/class-p4bks-blocks-covers-controllers.php
+++ b/classes/controller/blocks/class-p4bks-blocks-covers-controllers.php
@@ -4,16 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_Covers_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_Covers_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_Covers_Controller extends P4BKS_Blocks_Controller {
 
-
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'covers';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'covers';
 
 		/**
 		 * Shortcode UI setup for the shortcode.
@@ -71,7 +70,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Covers_Controller' ) ) {
 				'attrs' => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -138,7 +137,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Covers_Controller' ) ) {
 			];
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-happypoint-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-happypoint-controller.php
@@ -4,16 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_HappyPoint_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_HappyPoint_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_HappyPoint_Controller extends P4BKS_Blocks_Controller {
 
-		/**
-		 * Function to load the block and define its name.
-		 */
-		public function load() {
-			// --- Set here the name of your block ---
-			$this->block_name = 'happy_point';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'happy_point';
 
 		/**
 		 * Shortcode UI setup for the happypoint shortcode.
@@ -66,7 +65,7 @@ if ( ! class_exists( 'P4BKS_Blocks_HappyPoint_Controller' ) ) {
 				'attrs'         => $fields,
 			);
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -106,7 +105,7 @@ if ( ! class_exists( 'P4BKS_Blocks_HappyPoint_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-mediablock-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-mediablock-controller.php
@@ -11,13 +11,8 @@ if ( ! class_exists( 'P4BKS_Blocks_MediaBlock_Controller' ) ) {
 	 */
 	class P4BKS_Blocks_MediaBlock_Controller extends P4BKS_Blocks_Controller {
 
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'media_block';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'media_block';
 
 		/**
 		 * Shortcode UI setup for the tasks shortcode.
@@ -48,7 +43,7 @@ if ( ! class_exists( 'P4BKS_Blocks_MediaBlock_Controller' ) ) {
 				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/media_block.png' ) . '" />',
 				'attrs'         => $fields,
 			];
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -77,7 +72,7 @@ if ( ! class_exists( 'P4BKS_Blocks_MediaBlock_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $block_data );
+			$this->view->block( self::BLOCK_NAME, $block_data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-mediavideo-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-mediavideo-controller.php
@@ -4,16 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_MediaVideo_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_MediaVideo_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_MediaVideo_Controller extends P4BKS_Blocks_Controller {
 
-
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'media_video';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'media_video';
 
 		/**
 		 * Shortcode UI setup for the Mediavideo shortcode.
@@ -49,7 +48,7 @@ if ( ! class_exists( 'P4BKS_Blocks_MediaVideo_Controller' ) ) {
 				'attrs'         => $fields,
 			);
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -73,7 +72,7 @@ if ( ! class_exists( 'P4BKS_Blocks_MediaVideo_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-splittwocolumns-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-splittwocolumns-controller.php
@@ -11,14 +11,8 @@ if ( ! class_exists( 'P4BKS_Blocks_SplitTwoColumns_Controller' ) ) {
 	 */
 	class P4BKS_Blocks_SplitTwoColumns_Controller extends P4BKS_Blocks_Controller {
 
-
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'split_two_columns';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'split_two_columns';
 
 		/**
 		 * Shortcode UI setup for the shortcode.
@@ -102,7 +96,7 @@ if ( ! class_exists( 'P4BKS_Blocks_SplitTwoColumns_Controller' ) ) {
 				 * Include an icon with your shortcode. Optional.
 				 * Use a dashicon, or full HTML (e.g. <img src="/path/to/your/icon" />).
 				 */
-				'listItemImage' => '<img src="' . esc_url( plugins_url() . "/planet4-plugin-blocks/admin/images/$this->block_name.png" ) . '" />',
+				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/' . self::BLOCK_NAME . '.png' ) . '" />',
 
 				/*
 				 * Define the UI for attributes of the shortcode. Optional.
@@ -111,7 +105,7 @@ if ( ! class_exists( 'P4BKS_Blocks_SplitTwoColumns_Controller' ) ) {
 				'attrs' => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -151,7 +145,7 @@ if ( ! class_exists( 'P4BKS_Blocks_SplitTwoColumns_Controller' ) ) {
 			];
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-staticfourcolumn-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-staticfourcolumn-controller.php
@@ -11,13 +11,8 @@ if ( ! class_exists( 'P4BKS_Blocks_StaticFourColumn_Controller' ) ) {
 	 */
 	class P4BKS_Blocks_StaticFourColumn_Controller extends P4BKS_Blocks_Controller {
 
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'static_four_column';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'static_four_column';
 
 		/**
 		 * Shortcode UI setup for static four column shortcode.
@@ -96,7 +91,7 @@ if ( ! class_exists( 'P4BKS_Blocks_StaticFourColumn_Controller' ) ) {
 				'attrs'         => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -139,7 +134,7 @@ if ( ! class_exists( 'P4BKS_Blocks_StaticFourColumn_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $block_data );
+			$this->view->block( self::BLOCK_NAME, $block_data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-subheader-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-subheader-controller.php
@@ -4,15 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_Subheader_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_Subheader_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_Subheader_Controller extends P4BKS_Blocks_Controller {
 
-		/**
-		 * Function to load the block and define its name.
-		 */
-		public function load() {
-			$this->block_name = 'subheader';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'subheader';
 
 		/**
 		 * Shortcode UI setup for the subheader shortcode.
@@ -39,7 +39,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Subheader_Controller' ) ) {
 				'attrs'         => $fields,
 			);
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -68,7 +68,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Subheader_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-takeactionboxout-controllers.php
+++ b/classes/controller/blocks/class-p4bks-blocks-takeactionboxout-controllers.php
@@ -4,16 +4,15 @@ namespace P4BKS\Controllers\Blocks;
 
 if ( ! class_exists( 'P4BKS_Blocks_TakeActionBoxout_Controller' ) ) {
 
+	/**
+	 * Class P4BKS_Blocks_TakeActionBoxout_Controller
+	 *
+	 * @package P4BKS\Controllers\Blocks
+	 */
 	class P4BKS_Blocks_TakeActionBoxout_Controller extends P4BKS_Blocks_Controller {
 
-
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'take_action_boxout';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'take_action_boxout';
 
 		/**
 		 * Shortcode UI setup for the shortcode.
@@ -62,7 +61,7 @@ if ( ! class_exists( 'P4BKS_Blocks_TakeActionBoxout_Controller' ) ) {
 				'attrs'         => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -116,7 +115,7 @@ if ( ! class_exists( 'P4BKS_Blocks_TakeActionBoxout_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-tasks-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-tasks-controller.php
@@ -11,13 +11,8 @@ if ( ! class_exists( 'P4BKS_Blocks_Tasks_Controller' ) ) {
 	 */
 	class P4BKS_Blocks_Tasks_Controller extends P4BKS_Blocks_Controller {
 
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			$this->block_name = 'tasks';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'tasks';
 
 		/**
 		 * Shortcode UI setup for the tasks shortcode.
@@ -126,7 +121,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Tasks_Controller' ) ) {
 				'attrs'         => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -172,7 +167,7 @@ if ( ! class_exists( 'P4BKS_Blocks_Tasks_Controller' ) ) {
 
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $block_data );
+			$this->view->block( self::BLOCK_NAME, $block_data );
 
 			return ob_get_clean();
 		}

--- a/classes/controller/blocks/class-p4bks-blocks-twocolumn-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-twocolumn-controller.php
@@ -11,14 +11,8 @@ if ( ! class_exists( 'P4BKS_Blocks_TwoColumn_Controller' ) ) {
 	 */
 	class P4BKS_Blocks_TwoColumn_Controller extends P4BKS_Blocks_Controller {
 
-		/**
-		 * Override this method in order to give your block its own name.
-		 */
-		public function load() {
-			// --- Set here the name of your block ---
-			$this->block_name = 'two_columns';
-			parent::load();
-		}
+		/** @const string BLOCK_NAME */
+		const BLOCK_NAME = 'two_columns';
 
 		/**
 		 * Shortcode UI setup for the twocolumn shortcode.
@@ -137,7 +131,7 @@ if ( ! class_exists( 'P4BKS_Blocks_TwoColumn_Controller' ) ) {
 				 * Include an icon with your shortcode. Optional.
 				 * Use a dashicon, or full HTML (e.g. <img src="/path/to/your/icon" />).
 				 */
-				'listItemImage' => '<img src="' . esc_url( plugins_url() . "/planet4-plugin-blocks/admin/images/$this->block_name.png" ) . '" />',
+				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/' . self::BLOCK_NAME . '.png' ) . '" />',
 
 				/*
 				 * Define the UI for attributes of the shortcode. Optional.
@@ -146,7 +140,7 @@ if ( ! class_exists( 'P4BKS_Blocks_TwoColumn_Controller' ) ) {
 				'attrs' => $fields,
 			];
 
-			shortcode_ui_register_for_shortcode( 'shortcake_' . $this->block_name, $shortcode_ui_args );
+			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );
 		}
 
 		/**
@@ -168,7 +162,7 @@ if ( ! class_exists( 'P4BKS_Blocks_TwoColumn_Controller' ) ) {
 			];
 			// Shortcode callbacks must return content, hence, output buffering here.
 			ob_start();
-			$this->view->block( $this->block_name, $data );
+			$this->view->block( self::BLOCK_NAME, $data );
 
 			return ob_get_clean();
 		}


### PR DESCRIPTION
…tant along with the use of Late Static Binding. This way it is simpler to retrieve the name of a block (e.g. Covers::BLOCK_NAME ) and at the same time there is no longer requirement to override the load() method when developing a new block.