### PR TITLE
Add isset checks to the Carousel Header block to avoid fatal PHP error.

### DIFF
--- a/classes/controller/blocks/class-p4bks-blocks-carouselheader-controller.php
+++ b/classes/controller/blocks/class-p4bks-blocks-carouselheader-controller.php
@@ -119,12 +119,12 @@ if ( ! class_exists( 'P4BKS_Blocks_CarouselHeader_Controller' ) ) {
 			$attributes_temp = [];
 			for ( $i = 1; $i < 5; $i++ ) {
 				$temp_array      = [
-					"header_$i"      => $attributes[ "header_$i" ],
-					"subheader_$i"   => $attributes[ "header_$i" ],
-					"description_$i" => $attributes[ "description_$i" ],
-					"image_$i"       => $attributes[ "image_$i" ],
-					"link_text_$i"   => $attributes[ "link_text_$i" ],
-					"link_url_$i"    => $attributes[ "link_url_$i" ],
+					"header_$i"      => $attributes[ "header_$i" ] ?? '',
+					"subheader_$i"   => $attributes[ "header_$i" ] ?? '',
+					"description_$i" => $attributes[ "description_$i" ] ?? '',
+					"image_$i"       => $attributes[ "image_$i" ] ?? '',
+					"link_text_$i"   => $attributes[ "link_text_$i" ] ?? '',
+					"link_url_$i"    => $attributes[ "link_url_$i" ] ?? '',
 				];
 				$attributes_temp = array_merge( $attributes_temp, $temp_array );
 			}


### PR DESCRIPTION
Empty fields inside of the Shortcake UI are not added to the shortcode attributes. This means that these fields are then not set inside of the `$attributes` array in the `prepare_template()` method. This leads to a fatal PHP error.