### PR TITLE
Switching directories so that we can pull the shortcake from wpackagist

### DIFF
--- a/planet4-blocks.php
+++ b/planet4-blocks.php
@@ -30,7 +30,7 @@ if ( ! defined( 'P4BKS_REQUIRED_PLUGINS' ) )    define( 'P4BKS_REQUIRED_PLUGINS'
 	],
 	'shortcake' => [
 		'min_version' => '0.7.0',
-		'rel_path' => 'shortcake/shortcode-ui.php',
+		'rel_path' => 'shortcode-ui/shortcode-ui.php',
 	],
 ] );
 if ( ! defined( 'P4BKS_PLUGIN_BASENAME' ) )     define( 'P4BKS_PLUGIN_BASENAME',    plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Important: This update needs to run at the same time as the planet4-base update that uses the "wpackagist-plugin/shortcode-ui": "0.7.3" for pulling the shortcake plugin. 