### PR TITLE
Use direct call to `jetpack_photon_url()` to generate resized image.

### DIFF
--- a/classes/controller/blocks/class-carouselheader-controller.php
+++ b/classes/controller/blocks/class-carouselheader-controller.php
@@ -135,6 +135,7 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 				$temp_array = wp_get_attachment_image_src( $image_id, 'full' );
 				if ( false !== $temp_array && ! empty( $temp_array ) ) {
 					$attributes[ "image_$i" ] = $temp_array[0];
+					$attributes[ "image_{$i}_url"] = jetpack_photon_url( $temp_array[0], [ 'h' => 775 ] );
 				}
 				$temp_image                     = wp_prepare_attachment_for_js( $image_id );
 				$attributes[ "image_${i}_alt" ] = $temp_image['alt'] ?? '';

--- a/includes/blocks/carousel_header.twig
+++ b/includes/blocks/carousel_header.twig
@@ -22,7 +22,7 @@
 							{% if ( attribute( fields, 'header_'~i ) and attribute( fields, 'image_'~i ) ) %}
 								<div class="{{ loop.first ? 'carousel-item active': 'carousel-item' }}">
 									{% if ( attribute( fields, 'image_'~i ) ) %}
-										<img src="{{ attribute( fields, 'image_'~i ) }}" alt="{{ attribute( fields, 'image_'~i~'_alt' )}}">
+										<img src="{{ attribute( fields, 'image_'~i~'_url' ) }}" alt="{{ attribute( fields, 'image_'~i~'_alt' )}}">
 									{% endif %}
 									<div class="carousel-caption">
 										<div class="container main-header">


### PR DESCRIPTION
As an alternative to #109, this PR uses a direct call to `jetpack_photon_url()` to retrieve the resized image.

If this works, then the URL of the image should start with `https://i1.wp.com/` or similar, which is the domain of the WordPress.com image CDN.