### PR TITLE
Feature/fix retina image generation

### DIFF
--- a/classes/controller/blocks/class-articles-controller.php
+++ b/classes/controller/blocks/class-articles-controller.php
@@ -92,6 +92,7 @@ if ( ! class_exists( 'Articles_Controller' ) ) {
 				foreach ( $all_posts as $recent ) {
 					$recent['alt_text']  = '';
 					$recent['thumbnail'] = '';
+					$recent['author']    = get_the_author_meta( 'display_name', $recent['post_author'] );
 
 					if ( has_post_thumbnail( $recent['ID'] ) ) {
 						$recent['thumbnail'] = get_the_post_thumbnail_url( $recent['ID'], 'single-post-thumbnail' );

--- a/classes/controller/blocks/class-carouselheader-controller.php
+++ b/classes/controller/blocks/class-carouselheader-controller.php
@@ -151,10 +151,10 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 			$total_images = 0;
 			for ( $i = 1; $i < 5; $i++ ) {
 				$image_id   = $attributes[ "image_$i" ];
-				$temp_array = wp_get_attachment_image_src( $image_id, 'large' );
+				$temp_array = wp_get_attachment_image_src( $image_id, ['1118', '746'] );
 				if ( false !== $temp_array && ! empty( $temp_array ) ) {
-					$attributes[ "image_$i" ] = $temp_array[0];
-					$attributes[ "image_${i}_srcset" ] = wp_calculate_image_srcset(['1024', '768'], wp_get_attachment_image_src( $image_id, 'full' )[0], wp_get_attachment_metadata( $image_id ));
+					$attributes[ "image_$i" ]          = $temp_array[0];
+					$attributes[ "image_${i}_srcset" ] = wp_calculate_image_srcset(['1118', '746'], wp_get_attachment_image_src( $image_id, 'full' )[0], wp_get_attachment_metadata( $image_id ));
 					$total_images++;
 				}
 				$temp_image                     = wp_prepare_attachment_for_js( $image_id );

--- a/classes/controller/blocks/class-carouselheader-controller.php
+++ b/classes/controller/blocks/class-carouselheader-controller.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 			$total_images = 0;
 			for ( $i = 1; $i < 5; $i++ ) {
 				$image_id   = $attributes[ "image_$i" ];
-				$temp_array = wp_get_attachment_image_src( $image_id, 'full' );
+				$temp_array = wp_get_attachment_image_src( $image_id, 'large' );
 				if ( false !== $temp_array && ! empty( $temp_array ) ) {
 					$attributes[ "image_$i" ] = $temp_array[0];
 					$total_images++;

--- a/classes/controller/blocks/class-carouselheader-controller.php
+++ b/classes/controller/blocks/class-carouselheader-controller.php
@@ -154,6 +154,7 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 				$temp_array = wp_get_attachment_image_src( $image_id, 'large' );
 				if ( false !== $temp_array && ! empty( $temp_array ) ) {
 					$attributes[ "image_$i" ] = $temp_array[0];
+					$attributes[ "image_${i}_srcset" ] = wp_calculate_image_srcset(['1024', '768'], wp_get_attachment_image_src( $image_id, 'full' )[0], wp_get_attachment_metadata( $image_id ));
 					$total_images++;
 				}
 				$temp_image                     = wp_prepare_attachment_for_js( $image_id );

--- a/classes/controller/blocks/class-contentfourcolumn-controller.php
+++ b/classes/controller/blocks/class-contentfourcolumn-controller.php
@@ -25,6 +25,28 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 		 */
 		public function prepare_fields() {
 
+			$checkboxes                 = [];
+			$planet4_article_type_terms = get_terms(
+				[
+					'hide_empty' => false,
+					'orderby'    => 'name',
+					'taxonomy'   => 'p4-page-type',
+				]
+			);
+
+			// Construct a checkbox for each p4-page-type.
+			if ( ! empty( $planet4_article_type_terms ) ) {
+				foreach ( $planet4_article_type_terms as $term ) {
+					$checkboxes [] = [
+						'attr'        => 'p4_page_type_' . str_replace( '-', '_', $term->slug ),
+						'label'       => $term->name . ' Posts',
+						'description' => 'Use Posts that belong to ' . $term->name . ' type to populate the content of this block',
+						'type'        => 'checkbox',
+						'value'       => 'false',
+					];
+				}
+			}
+
 			$fields = [
 				[
 					'label' => __( 'Title. <i>If it is not defined, title will default to \'Publications\'</i>', 'planet4-blocks' ),
@@ -37,14 +59,6 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 					],
 				],
 				[
-					'attr'        => 'p4_page_types',
-					'label'       => __( 'Select a Planet4 Page Type', 'planet4-blocks' ),
-					'description' => __( 'Select a Planet4 Page Type. Only posts of this type will be used to populate the content of this block', 'planet4-blocks' ),
-					'type'        => 'term_select',
-					'taxonomy'    => 'p4-page-type',
-					'multiple'    => true,
-				],
-				[
 					'attr'        => 'select_tag',
 					'label'       => __( 'Select a Tag', 'planet4-blocks' ),
 					'description' => __( 'Associate this block with Posts that have a specific Tag', 'planet4-blocks' ),
@@ -53,6 +67,10 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 					'multiple'    => true,
 				],
 			];
+
+			if ( ! empty( $checkboxes ) ) {
+				$fields = array_merge( $fields, $checkboxes );
+			}
 
 			// Define the Shortcode UI arguments.
 			$shortcode_ui_args = [
@@ -77,20 +95,29 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
 
 			$raw_tags   = $attributes['select_tag'] ?? '';
-			$post_types = $attributes['p4_page_types'] ?? '';
+			$post_types = [];
+
+			// Filter p4_page_type keys from attributes array.
+			$post_types_temp = array_filter( $attributes, function ( $key ) {
+				return strpos( $key, 'p4_page_type' ) === 0 ;
+			}, ARRAY_FILTER_USE_KEY );
+
+			// If any p4_page_type was selected extract the term's slug to be used in the wp query below.
+			if ( ! empty( $post_types_temp ) ) {
+				foreach ( $post_types_temp as $type => $value ) {
+					if ( 'true' === $value ) {
+						$post_types[] = str_replace( '_', '-',
+							str_replace( 'p4_page_type_', '', $type )
+						);
+					}
+				}
+			}
 
 			// If any tag is selected convert the value to an array of tag ids.
 			if ( empty( $raw_tags ) || ! preg_split( '/^\d+(,\d+)*$/', $raw_tags ) ) {
 				$tag_ids = [];
 			} else {
 				$tag_ids = explode( ',', $raw_tags );
-			}
-
-			// If any planet4 post type is selected convert the value to an array of term ids.
-			if ( empty( $post_types ) || ! preg_split( '/^\d+(,\d+)*$/', $post_types ) ) {
-				$post_types = [];
-			} else {
-				$post_types = explode( ',', $post_types );
 			}
 
 			$posts_array = [];
@@ -112,8 +139,8 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 						'terms'    => $tag_ids,
 					],
 					[
-						'taxonomy' => 'p4-post-type',
-						'field'    => 'term_id',
+						'taxonomy' => 'p4-page-type',
+						'field'    => 'slug',
 						'terms'    => $post_types,
 					],
 				];
@@ -131,7 +158,7 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 				$query_args['tax_query'] = [
 					[
 						'taxonomy' => 'p4-page-type',
-						'field'    => 'term_id',
+						'field'    => 'slug',
 						'terms'    => $post_types,
 					],
 				];
@@ -164,7 +191,7 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 			}
 
 			$block_data = [
-				'title'  => ! empty( $attributes['title'] ) ? $attributes['title'] : 'Publications',
+				'title'  => ! empty( $attributes['title'] ) ? $attributes['title'] : __( 'Publications', 'planet4-blocks' ),
 				'posts'  => $posts_array,
 				'domain' => 'planet4-blocks',
 			];

--- a/includes/blocks/articles.twig
+++ b/includes/blocks/articles.twig
@@ -1,90 +1,80 @@
 {% block articles %}
-{% if ( recent_posts ) %}
-	<div class="article">
-		<div class="container">
-			<div class="row">
-				<div class="col-md-8 col-lg-9">
-					{% if ( fields.article_heading ) %}
-						<h3>{{ fields.article_heading }}</h3>
-					{% endif %}
-				</div>
-				<div class="col-md-4 col-lg-3 ml-auto hidden-sm-down">
-					<a class="btn btn-medium btn-blue btn-block" href="#">{{ __( 'READ ALL THE NEWS', domain ) }}</a>
-				</div>
-				<div class="topicwise-article-section clearfix col-md-12">
-					<ul class="topicwise-article-list list-unstyled hidden-sm-down">
-						{% for key,value in recent_posts %}
-							<li class="media topicwise-article-list-item {% if key == 1 %}my-5{% endif %}">
-								<img class="d-flex mr-3 topicwise-article-image"  src="{{ value.thumbnail|resize(350) }}"
-									srcset="{{ value.thumbnail|resize(350)|retina(1) }} 1x,
-									{{ value.thumbnail|resize(350)|retina(2) }}  2x,
-									{{ value.thumbnail|resize(350)|retina(3) }}  3x,
-									{{ value.thumbnail|resize(350)|retina(4) }}  4x" alt="{{ value.alt_text }}">
-								<div class="media-body topicwise-article-body">
-								<div class="topicwise-article-tags">
-									{% if ( value.category ) %}
-										{% for category_data in value.category %}
-											<a href="{{ category_data.href }}" class="article-topic-title"> {{ category_data.name }}</a>
-										{% endfor %}
-										<span class="article-topic-title-seprater"></span>
-									{% endif %}
-									{% if ( value.tags ) %}
-										{% for tags_data in value.tags %}
-											<a href={{ tags_data.href }} class="article-topic-tag">#{{ tags_data.name }}</a>
-										{% endfor %}
-									{% endif %}
-								</div>
-								{% if ( value.post_title ) %}
-									<a href="{{ value.permalink }}" class="mt-0 mb-1 article-headline">{{ value.post_title }}</a>
-								{% endif %}
-								<div class="article-write-info">
-									{% if ( value.post_modified ) %}
-										<span class="article-date">{{ value.post_modified|date("d M, Y") }}</span>
-									{% endif %}
-								</div>
-								{% if ( value.post_excerpt ) %}
-									<p class="article-content">{{ value.post_excerpt }}</p>
-								{% endif %}
-								</div>
-							</li>
-						{% endfor %}
-					</ul>
-					<ul class="topicwise-article-list list-unstyled hidden-sm-up">
-						{% for value in recent_posts %}
-							<li class="topicwise-article-list-item article-mobile-view {% if key == 1 %}my-5{% endif %}">
-								<div class="topicwise-article-body">
-									<div class="topicwise-article-tags">
-										{% if ( value.category ) %}
-											<span class="article-topic-title">{% for category_data in value.category %} {{ category_data.name }} {% endfor %}</span>
-											<span class="article-topic-title-seprater"></span>
-										{% endif %}
-										{% if ( value.tags ) %}
-											{% for tags_data in value.tags %}
-												<span class="article-topic-tag">#{{ tags_data.name }}</span>
-											{% endfor %}
-										{% endif %}
-									</div>
-									{% if ( value.post_title ) %}
-										<h4 class="mt-0 mb-1 article-headline">{{ value.post_title }}</h4>
-									{% endif %}
-									<div class="article-write-info">
-										{% if ( value.post_modified ) %}
-											<span class="article-date">{{ value.post_modified|date("d M, Y") }}</span>
-										{% endif %}
-									</div>
-								</div>
-								<img class="d-flex mr-3 topicwise-article-image"  src="{{ value.thumbnail|resize(350) }}"
-									srcset="{{ value.thumbnail|resize(350)|retina(1) }} 1x,
-									{{ value.thumbnail|resize(350)|retina(2) }}  2x,
-									{{ value.thumbnail|resize(350)|retina(3) }}  3x,
-									{{ value.thumbnail|resize(350)|retina(4) }}  4x" alt="{{ value.alt_text }}">
+	{% if ( recent_posts ) %}
+		<section class="article-listing page-section">
+			<div class="container">
+				<div class="row">
+					<header class="col-md-12 article-listing-intro">
+						<div class="col-md-7 col-lg-8 col-xl-9">
+							{% if ( fields.article_heading ) %}
+								<h3 class="page-section-header">{{ fields.article_heading }}</h3>
+							{% endif %}
+						</div>
+						<div class="col-md-5 col-lg-4 col-xl-3 ml-auto hidden-sm-down">
+							<a class="btn btn-secondary btn-block" href="#">{{ __( 'READ ALL THE NEWS', domain ) }}</a>
+						</div>
+					</header>
 
-							</li>
+					<div class="article-list-section clearfix col-md-12">
+						{% for key,value in recent_posts %}
+							<article class="article-list-item">
+								<a href="{{ value.permalink }}" class="article-list-item-image">
+									<img class="d-flex mr-3 topicwise-article-image"
+										 src="{{ value.thumbnail|resize(350) }}"
+										 srcset="{{ value.thumbnail|resize(350)|retina(1) }} 1x,
+											 	 {{ value.thumbnail|resize(350)|retina(2) }}  2x,
+											 	 {{ value.thumbnail|resize(350)|retina(3) }}  3x,
+											 	 {{ value.thumbnail|resize(350)|retina(4) }}  4x"
+										 alt="{{ value.alt_text }}">
+								</a>
+								<div class="article-list-item-body">
+									{% if ( value.tags ) %}
+										<ul class="tags-list article-list-item-tags">
+
+											{% if ( value.category ) %}
+												{% set categories = '' %}
+												{% for category_data in value.category %}
+													{% set categories = categories ~ ' ' ~ category_data.name|e('wp_kses_post')|raw %}
+												{% endfor %}
+												<li class="tag-item tag-item--main">{{ categories|raw }}</li>
+											{% endif %}
+											{% for tags_data in value.tags %}
+												<li class="tag-item"><a href="{{ tags_data.href }}">#{{ tags_data.name }}</a></li>
+											{% endfor %}
+
+										</ul>
+									{% endif %}
+
+									<header>
+										{% if ( value.post_title ) %}
+											<h4 class="article-list-item-headline">
+												<a href="{{ value.permalink }}">{{ value.post_title }}</a>
+											</h4>
+										{% endif %}
+										<p class="article-list-item-meta">
+											{% if ( value.author ) %}
+												<span class="article-list-item-author">by <a href="#">{{ value.author }}</a></span>
+											{% endif %}
+											{% if ( value.post_modified ) %}
+												<time class="article-list-item-date" datetime="">{{ value.post_modified|date("d M, Y") }}</time>
+											{% endif %}
+										</p>
+									</header>
+
+									{% if ( value.post_excerpt ) %}
+										<p class="article-list-item-content">
+											<a href="{{ value.permalink }}">{{ value.post_excerpt|e('wp_kses_post')|raw }}</a>
+										</p>
+									{% endif %}
+								</div>
+							</article>
 						{% endfor %}
-					</ul>
+					</div>
+
+					<div class="col-md-5 col-lg-4 col-xl-3 ml-auto hidden-md-up">
+						<a class="btn btn-medium btn-secondary btn-block mt42" href="#">{{ __( 'READ ALL THE NEWS', domain ) }}</a>
+					</div>
 				</div>
 			</div>
-		</div>
-	</div>
-{% endif %}
+		</section>
+	{% endif %}
 {% endblock %}

--- a/includes/blocks/campaign_thumbnail.twig
+++ b/includes/blocks/campaign_thumbnail.twig
@@ -3,7 +3,7 @@
 		<div class="campaign-thumbnail-block">
 			<div class="container">
 				{% if ( fields.title ) %}
-					<h2>{{ fields.title }}</h2>
+					<h2 class="page-section-header">{{ fields.title }}</h2>
 				{% endif %}
 				<div class="row thumbnail-largeview-container">
 					{% for tag in fields.tags %}

--- a/includes/blocks/carousel_header.twig
+++ b/includes/blocks/carousel_header.twig
@@ -24,12 +24,10 @@
 							{% if ( attribute( fields, 'header_'~i ) and attribute( fields, 'image_'~i ) ) %}
 								<div class="{{ loop.first ? 'carousel-item active': 'carousel-item' }}">
 									{% if ( attribute( fields, 'image_'~i ) ) %}
-										<img src="{{ attribute( fields, 'image_'~i )|resize(1118,746) }}"
-											 data-background-position="{{ attribute( fields, 'focus_image_'~i )}}"
-											 srcset="{{ attribute( fields, 'image_'~i )|resize(1118,746)|retina(1) }} 1x,
-											{{ attribute( fields, 'image_'~i )|resize(1118,746)|retina(2) }}  2x,
-											{{ attribute( fields, 'image_'~i )|resize(1118,746)|retina(3) }}  3x,
-											{{ attribute( fields, 'image_'~i )|resize(1118,746)|retina(4) }}  4x" alt="{{ attribute( fields, 'image_'~i~'_alt' )}}">
+									<img src="{{ fields['image_'~i] }}"
+										data-background-position="{{ fields['focus_image_'~i] }}"
+										srcset="{{ fields['image_'~i~'_srcset'] }}"
+										alt="{{ attribute( fields, 'image_'~i~'_alt' )}}">
 									{% endif %}
 									<div class="carousel-caption">
 										<div class="container main-header">

--- a/includes/blocks/content_four_column.twig
+++ b/includes/blocks/content_four_column.twig
@@ -1,11 +1,11 @@
 {% block content_four_column %}
 
 {% if ( posts ) %}
-	<div class="four-coloum-content">
+	<div class="four-column-content">
 		<div class="container">
 
 			{% if (title) %}
-				<h2>{{ __( title, 'planet4-blocks' ) }}</h2>
+				<h2 class="page-section-header">{{ title }}</h2>
 			{% endif %}
 
 			{% for post in posts %}
@@ -16,9 +16,9 @@
 				{% endif %}
 						<div class="col-md-4 col-lg-3 col-xl-3">
 							<a href="{{ post.permalink }}">
-								<div class="four-coloum-content-wrap clearfix">
-									<div class="four-coloum-content-info">
-										<div class="four-coloum-content-symbol">
+								<div class="four-column-content-wrap clearfix">
+									<div class="four-column-content-info">
+										<div class="four-column-content-symbol">
 											{% if ( post.thumbnail ) %}
 												<img src="{{ post.thumbnail|resize(255) }}"
 													 srcset="{{ post.thumbnail|resize(255)|retina(1) }} 1x,
@@ -28,7 +28,7 @@
 													 alt="{{ post.alt_text }}">
 											{% endif %}
 										</div>
-										<div class="four-coloum-content-information">
+										<div class="four-column-content-information">
 											{% if ( post.post_title ) %}
 												<h4>{{ post.post_title|e('wp_kses_post')|raw }}</h4>
 											{% endif %}
@@ -51,7 +51,7 @@
 			{% if ( posts|length > 4 ) %}
 				<div class="row mt-5 load-more-button-div">
 					<div class="col-md-4 col-lg-3 col-xl-3 mb-5">
-						<button class="btn btn-block btn-medium btn-small btn-transparent btn-load-more">
+						<button class="btn btn-block btn-medium btn-secondary btn-load-more">
 							{{ __( 'Load More', 'planet4-blocks' ) }}
 						</button>
 					</div>

--- a/includes/blocks/content_three_column.twig
+++ b/includes/blocks/content_three_column.twig
@@ -3,9 +3,9 @@
 		<div class="split-three-column">
 			<div class="container">
 				<div class="three-column-box">
-					<div class="three-column-info">
+					<div class="three-column-info col-md-11 col-lg-9">
 						{% if ( fields.title ) %}
-							<h2>{{ fields.title }}</h2>
+							<h2 class="page-section-header">{{ fields.title }}</h2>
 						{% endif %}
 						{% if ( fields.description ) %}
 							<p>{{ fields.description }}</p>

--- a/includes/blocks/covers.twig
+++ b/includes/blocks/covers.twig
@@ -17,17 +17,15 @@
 					{% elseif loop.index0 % covers_per_row == 0 and loop.index0 > covers_per_row %}
 						<div class="row row-hidden" style="display: none;">
 					{% endif %}
-							<div class="col-lg-4 col-md-6">
-								<div class="cover-card" style="background-image: url({{ cover.image }});">
-									{% if ( cover.tags ) %}
-										{% for tag in cover.tags %}
-											<a class="cover-card-tag" href="{{ tag.href|e('esc_url') }}">#{{ tag.name|e('wp_kses_post')|raw }}</a>
-										{% endfor %}
-									{% endif %}
-									<h2 class="cover-card-heading">{{ cover.title|e('wp_kses_post')|raw }}</h2>
-									<p>{{ cover.excerpt|truncate(25)|e('wp_kses_post')|raw }}</p>
-									<a class="btn btn-primary btn-transparent btn-block cover-card-btn" href="{{ cover.button_link|e('esc_url') }}">{{ cover.button_text }}</a>
-								</div>
+							<div class="cover-card card-one" style="background-image: url({{ cover.image }});">
+								{% if ( cover.tags ) %}
+									{% for tag in cover.tags %}
+										<a class="cover-card-tag" href="{{ tag.href|e('esc_url') }}">#{{ tag.name|e('wp_kses_post')|raw }}</a>
+									{% endfor %}
+								{% endif %}
+								<h2 class="cover-card-heading">{{ cover.title|e('wp_kses_post')|raw }}</h2>
+								<p>{{ cover.excerpt|truncate(25)|e('wp_kses_post')|raw }}</p>
+								<a class="btn btn-action btn-block cover-card-btn" href="{{ cover.button_link|e('esc_url') }}">{{ cover.button_text }}</a>
 							</div>
 					{% if ( ( loop.index0 % covers_per_row == (covers_per_row - 1) and loop.index0 > covers_per_row ) or loop.last) %}
 						</div>
@@ -35,7 +33,7 @@
 				{% endfor %}
 				{% if ( covers|length > covers_per_row and fields.button_text ) %}
 					<div class="col-lg-4 col-md-6 mb-5">
-						<button class="btn btn-block btn-medium btn-small btn-transparent btn-load-more-covers btn-load-more">{{ fields.button_text }}</button>
+						<button class="btn btn-block btn-small btn-secondary">{{ fields.button_text }}</button>
 					</div>
 				{% endif %}
 			</div>

--- a/includes/blocks/media_block.twig
+++ b/includes/blocks/media_block.twig
@@ -1,6 +1,6 @@
 {% block media %}
 	{% if ( fields.image ) %}
-		<div class="block-media">
+		<div class="block-media container">
 			<img src="{{ fields.image|resize(640) }}"
 				 srcset="{{ fields.image|resize(640)|retina(1) }} 1x,
 						 {{ fields.image|resize(640)|retina(2) }} 2x,

--- a/includes/blocks/media_video.twig
+++ b/includes/blocks/media_video.twig
@@ -3,7 +3,7 @@
 		<div class="video-block">
 			<div class="container">
 				{% if ( fields.video_title ) %}
-					<h2>{{ fields.video_title }}</h2>
+					<h2 class="page-section-header">{{ fields.video_title }}</h2>
 				{% endif %}
 				{% if ( fields.youtube_id ) %}
 					<div class="video-section">

--- a/includes/blocks/static_four_column.twig
+++ b/includes/blocks/static_four_column.twig
@@ -1,50 +1,40 @@
 {% block four_column %}
 
 	{% if ( fields ) %}
-
-		<div class="four-coloum">
+		<section class="four-column">
 			<div class="container">
-                {% if ( fields.title ) %}
+				{% if ( fields.title ) %}
 					<h2>{{ fields.title|e('wp_kses_post')|raw }}</h2>
-                {% endif %}
+				{% endif %}
 				<div class="row">
 					{% for i in 1..4 %}
-						<div class="col-md-6 col-lg-3 col-xl-3">
-							<div class="four-coloum-wrap clearfix">
-								{% if ( fields['attachment_'~i] ) %}
-									<div class="four-coloum-symbol">
-										<img src="{{ fields['attachment_'~i]|resize(200) }}"
-											 srcset="{{ fields['attachment_'~i]|resize(200)|retina(1) }} 1x,
-												     {{ fields['attachment_'~i]|resize(200)|retina(2) }} 2x,
-												     {{ fields['attachment_'~i]|resize(200)|retina(3) }} 3x,
-												     {{ fields['attachment_'~i]|resize(200)|retina(4) }} 4x"
-											 alt="">
-									</div>
+						<div class="col-md-6 col-lg-3 col-xl-3 four-column-wrap">
+							{% if ( fields['attachment_'~i] ) %}
+								<img src="{{ fields['attachment_'~i]|resize(200) }}"
+									 srcset="{{ fields['attachment_'~i]|resize(200)|retina(1) }} 1x,
+											 {{ fields['attachment_'~i]|resize(200)|retina(2) }} 2x,
+											 {{ fields['attachment_'~i]|resize(200)|retina(3) }} 3x,
+											 {{ fields['attachment_'~i]|resize(200)|retina(4) }} 4x"
+									 alt="" class="four-column-symbol">
+							{% endif %}
+							<div class="four-column-information">
+								{% if ( attribute( fields, 'title_'~i ) ) %}
+									<h5>{{ fields['title_'~i]|e('wp_kses_post')|raw }}</h5>
 								{% endif %}
-								<div class="four-coloum-info">
-									<div class="four-coloum-information">
-										{% if ( attribute( fields, 'title_'~i ) ) %}
-											<h5>{{ fields['title_'~i]|e('wp_kses_post')|raw }}</h5>
-										{% endif %}
-										{% if ( attribute( fields, 'description_'~i )  ) %}
-											<p>{{ fields['description_'~i]|e('wp_kses_post')|raw }}</p>
-										{% endif %}
-										<div class="four-coloum-action">
-											{% if ( attribute( fields, 'link_text_'~i ) ) %}
-												<a href="{{ fields['link_url_'~i]|e('esc_url') }}">
-													{{ fields['link_text_'~i]|e('wp_kses_post')|raw }} >
-												</a>
-											{% endif %}
-										</div>
-									</div>
-								</div>
+								{% if ( attribute( fields, 'description_'~i )  ) %}
+									<p>{{ fields['description_'~i]|e('wp_kses_post')|raw }}</p>
+								{% endif %}
+								{% if ( attribute( fields, 'link_text_'~i ) ) %}
+									<a href="{{ fields['link_url_'~i]|e('esc_url') }}">
+										{{ fields['link_text_'~i]|e('wp_kses_post')|raw }}
+									</a>
+								{% endif %}
 							</div>
 						</div>
 					{% endfor %}
 				</div>
 			</div>
-		</div>
-
+		</section>
 	{% endif %}
 
 {% endblock %}

--- a/includes/blocks/take_action_boxout.twig
+++ b/includes/blocks/take_action_boxout.twig
@@ -18,7 +18,7 @@
 				<p>{{ page.excerpt|excerpt(25)|raw }}</p>
 			{% endif %}
 			{% if ( page.link ) %}
-				<a class="btn btn-primary btn-transparent btn-block cover-card-btn" href="{{ page.link }}">
+				<a class="btn btn-action btn-block cover-card-btn" href="{{ page.link }}">
 					{{ __('take action', 'planet4-master-theme') }}
 				</a>
 			{% endif %}

--- a/includes/blocks/tasks.twig
+++ b/includes/blocks/tasks.twig
@@ -49,7 +49,7 @@
 													{% endif %}
 													{% if ( fields['button_text_'~i] and fields['button_link_'~i] ) %}
 														<br>
-														<a class="btn btn-small btn-medium secondary-button"
+														<a class="btn btn-small btn-medium btn-secondary"
 														   href="{{ fields['button_link_'~i] }}">{{ fields['button_text_'~i] }}
 														</a>
 													{% endif %}
@@ -116,7 +116,7 @@
 												</div>
 
 												{% if ( fields['button_text_'~i] and fields['button_text_'~i] ) %}
-													<a class="btn btn-small btn-medium secondary-button"
+													<a class="btn btn-small btn-medium btn-secondary"
 													   href="{{ fields['button_link_'~i] }}">{{ fields['button_text_'~i] }}
 													</a>
 												{% endif %}

--- a/includes/blocks/two_columns.twig
+++ b/includes/blocks/two_columns.twig
@@ -10,7 +10,7 @@
                         <p>{{ fields.description_1|e('wp_kses_post')|raw }}</p>
                     {% endif %}
                     {% if ( fields.button_text_1 and fields.button_link_1 ) %}
-                        <a href="{{ fields.button_link_1 }}" class="btn btn-light-blue btn-normal">{{ fields.button_text_1 }}</a>
+                        <a href="{{ fields.button_link_1 }}" class="btn btn-secondary">{{ fields.button_text_1 }}</a>
                     {% endif %}
                 </div>
                 <div class="col-md-12 col-lg-6 col-sm-12">
@@ -21,7 +21,7 @@
                         <p>{{ fields.description_2|e('wp_kses_post')|raw }}</p>
                     {% endif %}
                     {% if ( fields.button_text_2 and fields.button_link_2 ) %}
-                        <a href="{{ fields.button_link_2 }}" class="btn btn-light-blue btn-normal">{{ fields.button_text_2 }}</a>
+                        <a href="{{ fields.button_link_2 }}" class="btn btn-secondary">{{ fields.button_text_2 }}</a>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
Uses wp_calculate_image_srcset() to generate retina sizes. This hooks into low-lying Wordpress functionality, respected by other image manipulation libraries - notably WP-Stateless.

This also fixes:
- the retina image generation which was non-functional before (it only created a series of same-sized images in the srcset)
- Displays 'large' image by default instead of 'full' image. 

By merging this we'll re-introduce CDN image delivery on docker.p4.greenpeace.org, where with only the raw Timber resize code the images were being delivered locally.

This commit is a first-pass, representative of how the code in all other blocks should be generating image sizes.  

Help wanted:
- modifying other plugin block classes and templates
- registering standard image sizes with [add_image_size](https://developer.wordpress.org/reference/functions/add_image_size/)
- removing hardcoded '1024,768' maximum image size in line `wp_calculate_image_srcset(['1024', '768'], ... ` https://github.com/greenpeace/planet4-plugin-blocks/pull/121/commits/a723a3ae3d817fc68bdf504c92c0af7b152b5a38#diff-7ff25cf52abdb904511dd5ae2e7bd224R157
