### PR TITLE
Replaced p4-page-type select box with checkboxes.

### DIFF
--- a/classes/controller/blocks/class-contentfourcolumn-controller.php
+++ b/classes/controller/blocks/class-contentfourcolumn-controller.php
@@ -25,6 +25,28 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 		 */
 		public function prepare_fields() {
 
+			$checkboxes                 = [];
+			$planet4_article_type_terms = get_terms(
+				[
+					'hide_empty' => false,
+					'orderby'    => 'name',
+					'taxonomy'   => 'p4-page-type',
+				]
+			);
+
+			// Construct a checkbox for each p4-page-type.
+			if ( ! empty( $planet4_article_type_terms ) ) {
+				foreach ( $planet4_article_type_terms as $term ) {
+					$checkboxes [] = [
+						'attr'        => 'p4_page_type_' . str_replace( '-', '_', $term->slug ),
+						'label'       => $term->name . ' Posts',
+						'description' => 'Use Posts that belong to ' . $term->name . ' type to populate the content of this block',
+						'type'        => 'checkbox',
+						'value'       => 'publication' === $term->slug ? 'true' : 'false',
+					];
+				}
+			}
+
 			$fields = [
 				[
 					'label' => __( 'Title. <i>If it is not defined, title will default to \'Publications\'</i>', 'planet4-blocks' ),
@@ -37,14 +59,6 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 					],
 				],
 				[
-					'attr'        => 'p4_page_types',
-					'label'       => __( 'Select a Planet4 Page Type', 'planet4-blocks' ),
-					'description' => __( 'Select a Planet4 Page Type. Only posts of this type will be used to populate the content of this block', 'planet4-blocks' ),
-					'type'        => 'term_select',
-					'taxonomy'    => 'p4-page-type',
-					'multiple'    => true,
-				],
-				[
 					'attr'        => 'select_tag',
 					'label'       => __( 'Select a Tag', 'planet4-blocks' ),
 					'description' => __( 'Associate this block with Posts that have a specific Tag', 'planet4-blocks' ),
@@ -53,6 +67,10 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 					'multiple'    => true,
 				],
 			];
+
+			if ( ! empty( $checkboxes ) ) {
+				$fields = array_merge( $fields, $checkboxes );
+			}
 
 			// Define the Shortcode UI arguments.
 			$shortcode_ui_args = [
@@ -77,20 +95,29 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
 
 			$raw_tags   = $attributes['select_tag'] ?? '';
-			$post_types = $attributes['p4_page_types'] ?? '';
+			$post_types = [];
+
+			// Filter p4_page_type keys from attributes array.
+			$post_types_temp = array_filter( $attributes, function ( $key ) {
+				return strpos( $key, 'p4_page_type' ) === 0 ;
+			}, ARRAY_FILTER_USE_KEY );
+
+			// If any p4_page_type was selected extract the term's slug to be used in the wp query below.
+			if ( ! empty( $post_types_temp ) ) {
+				foreach ( $post_types_temp as $type => $value ) {
+					if ( 'true' === $value ) {
+						$post_types[] = str_replace( '_', '-',
+							str_replace( 'p4_page_type_', '', $type )
+						);
+					}
+				}
+			}
 
 			// If any tag is selected convert the value to an array of tag ids.
 			if ( empty( $raw_tags ) || ! preg_split( '/^\d+(,\d+)*$/', $raw_tags ) ) {
 				$tag_ids = [];
 			} else {
 				$tag_ids = explode( ',', $raw_tags );
-			}
-
-			// If any planet4 post type is selected convert the value to an array of term ids.
-			if ( empty( $post_types ) || ! preg_split( '/^\d+(,\d+)*$/', $post_types ) ) {
-				$post_types = [];
-			} else {
-				$post_types = explode( ',', $post_types );
 			}
 
 			$posts_array = [];
@@ -112,8 +139,8 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 						'terms'    => $tag_ids,
 					],
 					[
-						'taxonomy' => 'p4-post-type',
-						'field'    => 'term_id',
+						'taxonomy' => 'p4-page-type',
+						'field'    => 'slug',
 						'terms'    => $post_types,
 					],
 				];
@@ -131,7 +158,7 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 				$query_args['tax_query'] = [
 					[
 						'taxonomy' => 'p4-page-type',
-						'field'    => 'term_id',
+						'field'    => 'slug',
 						'terms'    => $post_types,
 					],
 				];


### PR DESCRIPTION
Replaced p4-page-type select box with checkboxes in content four column block.
Made Publication post type selected by default.
Fixed bug when both p4-page-type and tag were selected.