### PR TITLE
Remove setting publication post type as default. 

### DIFF
--- a/classes/controller/blocks/class-contentfourcolumn-controller.php
+++ b/classes/controller/blocks/class-contentfourcolumn-controller.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 						'label'       => $term->name . ' Posts',
 						'description' => 'Use Posts that belong to ' . $term->name . ' type to populate the content of this block',
 						'type'        => 'checkbox',
-						'value'       => 'publication' === $term->slug ? 'true' : 'false',
+						'value'       => 'false',
 					];
 				}
 			}


### PR DESCRIPTION
Set all checkboxes in content four column as false/unchecked.
If you try to re-edit the block in the post editor it always appears the _publication_ checkbox as checked.