### PR TITLE
Remove timber resizing from carousel split block.

### DIFF
--- a/classes/controller/blocks/class-carouselsplit-controller.php
+++ b/classes/controller/blocks/class-carouselsplit-controller.php
@@ -74,6 +74,8 @@ if ( ! class_exists( 'CarouselSplit_Controller' ) ) {
 					$image['caption'] = $temp_image['caption'];
 					$image['alt']     = $temp_image['alt'];
 					$image['credit']  = $temp_meta['image_meta']['copyright'];
+					$image['srcset']  = wp_get_attachment_image_srcset( $image_id, 'full', wp_get_attachment_metadata( $image_id ) );
+					$image['sizes']   = wp_calculate_image_sizes( 'full', null, null, $image_id );
 					$images[]         = $image;
 				}
 			}

--- a/includes/blocks/carousel_split.twig
+++ b/includes/blocks/carousel_split.twig
@@ -22,11 +22,9 @@
 									{% if ( image.credit ) %}
 										<h5 class="carousel-item-credit">{{ image.credit }}</h5>
 									{% endif %}
-									<img src="{{ image.url|resize(1106) }}"
-										 srcset="{{ image.url|resize(1106)|retina(1) }} 1x,
-									 			 {{ image.url|resize(1106)|retina(2) }} 2x,
-									 			 {{ image.url|resize(1106)|retina(3) }} 3x,
-									 			 {{ image.url|resize(1106)|retina(4) }} 4x"
+									<img src="{{ image.url }}"
+										 srcset="{{ image.srcset }}"
+										 sizes="{{ image.sizes }}"
 										 alt="{{ image.alt }}">
 									<div class="carousel-caption">
 										{% if ( image.title ) %}


### PR DESCRIPTION
 Use full wordpress image size for it's images and srcset generated by wordpress.