### PR TITLE
Remove next css class assignment in second slide for styling reasons.

### DIFF
--- a/includes/blocks/carousel_header.twig
+++ b/includes/blocks/carousel_header.twig
@@ -14,8 +14,6 @@
 						{% if ( attribute( fields, 'header_'~i ) and attribute( fields, 'image_'~i ) ) %}
 							{% if ( loop.first ) %}
 								{% set css_class = 'carousel-item active' %}
-							{% elseif ( loop.index == 2 ) %}
-								{% set css_class = 'carousel-item next' %}
 							{% else %}
 								{% set css_class = 'carousel-item' %}
 							{% endif %}


### PR DESCRIPTION
Remove assignment of 'next' class to 2nd slide during initial loading as it results in 2nd slide's header & subheader text blending with 1st slide's header & subheader (opacity: 1 set by css).
Sliding and wrapping functionality is not impaired.