### PR TITLE
Button on split-two-columns-block should be btn-small

### DIFF
--- a/includes/blocks/split_two_columns.twig
+++ b/includes/blocks/split_two_columns.twig
@@ -60,7 +60,7 @@
 					<p class="split-two-column-item-subtitle">{{ campaign.description|truncate(25, true)|raw }}</p>
 				{% endif %}
 				{% if ( campaign.button_text and campaign.button_link ) %}
-					<a class="btn btn-small btn-medium btn-primary btn-block split-two-column-item-button" href="{{ campaign.button_link }}">{{ campaign.button_text }}</a>
+					<a class="btn btn-small btn-primary btn-block split-two-column-item-button" href="{{ campaign.button_link }}">{{ campaign.button_text }}</a>
 				{% endif %}
 			</div>
 		</div>
@@ -68,4 +68,3 @@
 {% endif %}
 
 {% endblock %}
-


### PR DESCRIPTION
A minor markup change based on design fixes at greenpeace/planet4-presentation-layer#196