### PR TITLE
Remove cover cards gradient on passive state

### DIFF
--- a/includes/blocks/covers.twig
+++ b/includes/blocks/covers.twig
@@ -14,7 +14,7 @@
 				<div class="row limit-visibility">
 					{% for cover in covers %}
 						<div class="col-lg-4 col-md-6">
-							<div class="cover-card card-one" style="background-image: linear-gradient(180deg, rgba(213, 239, 242, 1), rgba(255, 255, 255, 0.3)), url({{ cover.image }});">
+							<div class="cover-card card-one" style="background-image: url({{ cover.image }});">
 								{% if ( cover.tags ) %}
 									{% for tag in cover.tags %}
 										<a class="cover-card-tag"

--- a/includes/blocks/take_action_boxout.twig
+++ b/includes/blocks/take_action_boxout.twig
@@ -3,7 +3,7 @@
 	{% if ( page ) %}
 
 		{% if ( page.image ) %}
-			{% set bg_image = 'style="background-image: linear-gradient(180deg, rgba(213, 239, 242, 1), rgba(255, 255, 255, 0.3)), url(\''~page.image~'\');"' %}
+			{% set bg_image = 'style="background-image: url(\''~page.image~'\');"' %}
 		{% else %}
 			{% set bg_image = '' %}
 		{% endif %}


### PR DESCRIPTION
This are the new gradient changes per designers feedback. We are removing gradients from cover cards passive and will have gradients only on hover.

Relevant frontend PR: greenpeace/planet4-presentation-layer#208