### PR TITLE
1634 action covers sort

### DIFF
--- a/classes/controller/blocks/class-covers-controllers.php
+++ b/classes/controller/blocks/class-covers-controllers.php
@@ -114,8 +114,8 @@ if ( ! class_exists( 'Covers_Controller' ) ) {
 					'post_type'   => 'page',
 					'post_status' => 'publish',
 					'post_parent' => $parent_act_id,
-					'orderby'     => 'post_date',
-					'order'       => 'DESC',
+					'orderby'     => 'menu_order',
+					'order'       => 'ASC',
 					'numberposts' => P4BKS_COVERS_NUM,
 				];
 				// If user selected a tag to associate with the Take Action page covers.


### PR DESCRIPTION
After discussing with product owner we decided to make use of the built in functionality wp offers for this task. So, we sort take action covers by the built-in Order field. Editors can set this field to make the covers appear with the exact same order they appear inside the Pages tab.