### PR TITLE
Sow tag name on action cards instead of slug

### DIFF
--- a/classes/controller/blocks/class-takeactionboxout-controllers.php
+++ b/classes/controller/blocks/class-takeactionboxout-controllers.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'TakeActionBoxout_Controller' ) ) {
 
 			// Populate variables.
 			$block = [
-				'first_tag'      => null === $tag ? '' : $tag->slug,
+				'first_tag'      => null === $tag ? '' : $tag->name,
 				'first_tag_link' => null === $tag ? '' : get_tag_link( $tag ),
 				'title'          => null === $page ? '' : $page->post_title,
 				'excerpt'        => null === $page ? '' : $page->post_excerpt,


### PR DESCRIPTION
This for the "take action" cards on Posts. Currently these display the tag slug instead of the tag name.

This is per this [comment](https://jira.greenpeace.org/browse/PLANET-1581?focusedCommentId=61352&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-61352).