### PR TITLE
PLANET-1771 Carousel block image/attachment caption and credits

### DIFF
--- a/classes/controller/blocks/class-carousel-controller.php
+++ b/classes/controller/blocks/class-carousel-controller.php
@@ -115,16 +115,14 @@ if ( ! class_exists( 'Carousel_Controller' ) ) {
 
 			foreach ( $explode_multiple_image_array as $image_id ) {
 
-				$image_data_array             = wp_get_attachment_image_src( $image_id, 'retina-large' );
-				$images_data['image_src']     = $image_data_array[0];
-				$images_data['image_srcset']  = wp_get_attachment_image_srcset( $image_id, 'retina-large', wp_get_attachment_metadata( $image_id ) );
-				$images_data['image_sizes']   = wp_calculate_image_sizes( 'retina-large', null, null, $image_id );
-				$images_data['alt_text']      = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
-				$image_metadata               = get_post( $image_id );
-				$attachment_fields            = get_post_custom( $image_id );
-				$images_data['credits']       = ( isset( $attachment_fields['_credit_text'][0] ) && ! empty( $attachment_fields['_credit_text'][0] ) ) ? $attachment_fields['_credit_text'][0] : '';
-				$images_data['title']         = $image_metadata->post_title;
-				$images_data['description']   = $image_metadata->post_content;
+				$image_data_array            = wp_get_attachment_image_src( $image_id, 'retina-large' );
+				$images_data['image_src']    = $image_data_array[0];
+				$images_data['image_srcset'] = wp_get_attachment_image_srcset( $image_id, 'retina-large', wp_get_attachment_metadata( $image_id ) );
+				$images_data['image_sizes']  = wp_calculate_image_sizes( 'retina-large', null, null, $image_id );
+				$images_data['alt_text']     = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+				$attachment_fields           = get_post_custom( $image_id );
+				$images_data['credits']      = ( isset( $attachment_fields['_credit_text'][0] ) && ! empty( $attachment_fields['_credit_text'][0] ) ) ? $attachment_fields['_credit_text'][0] : '';
+				$images_data['caption']      = wp_get_attachment_caption( $image_id );
 
 				$images[] = $images_data;
 			}

--- a/includes/blocks/carousel.twig
+++ b/includes/blocks/carousel.twig
@@ -16,21 +16,20 @@
 			<div class="carousel-inner" role="listbox">
 				{% for key,single_image in images %}
 					<div class="carousel-item {% if key == 0 %}active{% endif %}">
-						{% if ( single_image.credits ) %}
-							<h5 class="carousal-item-credit">{{ single_image.credits }}</h5>
-						{% endif %}
 						<img src="{{ single_image.image_src }}"
 							 srcset="{{ single_image.image_srcset }}"
 							 sizes="{{ single_image.image_sizes }}"
 							 alt="{{ single_image.alt_text }}">
-						<div class="carousel-caption">
-							{% if ( single_image.title ) %}
-								<h3>{{ single_image.title }}</h3>
-							{% endif %}
-							{% if ( single_image.description ) %}
-								<p class="d-none d-md-block">{{ single_image.description }}</p>
-							{% endif %}
-						</div>
+						{% if ( single_image.caption or single_image.credits ) %}
+							<div class="carousel-caption">
+								{% if ( single_image.caption ) %}
+									<h3>{{ single_image.caption }}</h3>
+								{% endif %}
+								{% if ( single_image.credits ) %}
+									<p class="d-none d-md-block">{{ single_image.credits }}</p>
+								{% endif %}
+							</div>
+						{% endif %}
 					</div>
 				{% endfor %}
 			</div>


### PR DESCRIPTION
Change carousel block to use image/attachment caption and credit fields. 
Remove image caption from top right corner in carousel block.
Do not show blue overlay if neither of image caption and credits are defined.
[Issue 1771](https://jira.greenpeace.org/browse/PLANET-1771)