### PR TITLE
PLANET-1926 Carousel header responsive images

### DIFF
--- a/classes/controller/blocks/class-carouselheader-controller.php
+++ b/classes/controller/blocks/class-carouselheader-controller.php
@@ -156,7 +156,8 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 				$temp_array = wp_get_attachment_image_src( $image_id, 'retina-large' );
 				if ( false !== $temp_array && ! empty( $temp_array ) ) {
 					$attributes[ "image_$i" ]          = $temp_array[0];
-					$attributes[ "image_${i}_srcset" ] = wp_calculate_image_srcset( 'retina-large', wp_get_attachment_image_src( $image_id, 'retina-large' )[0], wp_get_attachment_metadata( $image_id ));
+					$attributes[ "image_${i}_srcset" ] = wp_get_attachment_image_srcset( $image_id, 'retina-large', wp_get_attachment_metadata( $image_id ) );
+					$attributes[ "image_${i}_sizes" ]  = wp_calculate_image_sizes( 'retina-large', null, null, $image_id );
 					$total_images++;
 				}
 				$temp_image                     = wp_prepare_attachment_for_js( $image_id );

--- a/includes/blocks/carousel_header.twig
+++ b/includes/blocks/carousel_header.twig
@@ -22,6 +22,7 @@
 									<img src="{{ fields['image_'~i] }}"
 										 data-background-position="{{ fields['focus_image_'~i] }}"
 										 srcset="{{ fields['image_'~i~'_srcset'] }}"
+										 sizes="{{ fields['image_'~i~'_sizes'] }}"
 										 alt="{{ attribute( fields, 'image_'~i~'_alt' ) }}">
 								{% endif %}
 								<div class="carousel-caption">


### PR DESCRIPTION
Calculate img srcset for image in carousel header based on retina-large size
[Issue 1926](https://jira.greenpeace.org/browse/PLANET-1926)

This is related to https://github.com/greenpeace/planet4-master-theme/pull/355