### PR TITLE
PLANET-1924 Articles block portrait images

### DIFF
--- a/classes/controller/blocks/class-articles-controller.php
+++ b/classes/controller/blocks/class-articles-controller.php
@@ -177,10 +177,11 @@ if ( ! class_exists( 'Articles_Controller' ) ) {
 					$recent['author']    = '' === $author_override ? get_the_author_meta( 'display_name', $recent['post_author'] ) : $author_override;
 
 					if ( has_post_thumbnail( $recent['ID'] ) ) {
-						$recent['thumbnail'] = get_the_post_thumbnail_url( $recent['ID'], 'medium' );
-						$img_id              = get_post_thumbnail_id( $recent['ID'] );
-						$recent['alt_text']  = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
-						$recent['srcset']    = wp_calculate_image_srcset( [ '400', '267' ], wp_get_attachment_image_src( $img_id, 'medium' )[0], wp_get_attachment_metadata( $img_id ) );
+						$recent['thumbnail']       = get_the_post_thumbnail_url( $recent['ID'], 'articles-medium-large' );
+						$img_id                    = get_post_thumbnail_id( $recent['ID'] );
+						$dimensions                = wp_get_attachment_metadata( $img_id );
+						$recent['thumbnail_ratio'] = ( isset( $dimensions['height'] ) && $dimensions['height'] > 0 ) ? $dimensions['width'] / $dimensions['height'] : 1;
+						$recent['alt_text']        = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
 					}
 
 					$wp_tags = wp_get_post_tags( $recent['ID'] );

--- a/includes/blocks/articles.twig
+++ b/includes/blocks/articles.twig
@@ -17,11 +17,25 @@
 					<div class="article-list-section clearfix col-md-12">
 						{% for key,value in recent_posts %}
 							<article class="article-list-item">
-								<a href="{{ value.permalink }}" class="article-list-item-image">
-									<img class="d-flex mr-3 topicwise-article-image"
-										 src="{{ value.thumbnail }}"
-										 alt="{{ value.alt_text }}">
-								</a>
+								{% if value.thumbnail_ratio < 1 %}
+									<div class="article-list-item-image">
+										<div class="article-image-holder">
+											<a href="{{ value.permalink }}">
+												<img class="d-flex topicwise-article-image"
+												     src="{{ value.thumbnail }}"
+												     alt="{{ value.alt_text }}">
+											</a>
+										</div>
+									</div>
+								{% else %}
+									<div class="article-list-item-image article-list-item-image-max-width">
+										<a href="{{ value.permalink }}">
+											<img class="d-flex mr-3 topicwise-article-image"
+											     src="{{ value.thumbnail }}"
+											     alt="{{ value.alt_text }}">
+										</a>
+									</div>
+								{% endif %}
 								<div class="article-list-item-body">
 									{% if ( value.tags ) %}
 										<ul class="tags-list article-list-item-tags">


### PR DESCRIPTION
Use custom image size for articles block images.
Use different markup for images in articles block depending on their aspect ratio.

This PR is related to [this](https://github.com/greenpeace/planet4-master-theme/pull/361)

You can check how it looks [here](https://jira.greenpeace.org/browse/PLANET-1924?focusedCommentId=62674&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-62674)
[Issue 1814](https://jira.greenpeace.org/browse/PLANET-1814)
[Issue 1924](https://jira.greenpeace.org/browse/PLANET-1924)