### PR TITLE
PLANET-1868 - Adjust four column block to make it responsive

### DIFF
--- a/includes/blocks/static_four_column.twig
+++ b/includes/blocks/static_four_column.twig
@@ -7,39 +7,41 @@
 				{% endif %}
 				<div class="row">
 					{% for i in 1..4 %}
-						<div class="col-md-6 col-lg four-column-wrap">
-							{% set link_url = fields['link_url_'~i] %}
-							{% if ( fields['attachment_'~i] and link_url ) %}
-								<div class="four-column-symbol-container">
-									<div class="four-column-symbol">
-										<a href="{{ link_url|e('esc_url') }}">
-											<img src="{{ fields['attachment_'~i] }}" alt="">
-										</a>
+						{% if fields['title_'~i] %}
+							<div class="col-md-6 col-lg four-column-wrap">
+								{% set link_url = fields['link_url_'~i] %}
+								{% if ( fields['attachment_'~i] and link_url ) %}
+									<div class="four-column-symbol-container">
+										<div class="four-column-symbol">
+											<a href="{{ link_url|e('esc_url') }}">
+												<img src="{{ fields['attachment_'~i] }}" alt="{{ fields['title_'~i] }}">
+											</a>
+										</div>
 									</div>
+								{% elseif (fields['attachment_'~i]) %}
+									<div class="four-column-symbol-container">
+										<img src="{{ fields['attachment_'~i] }}" alt="{{ fields['title_'~i] }}">
+									</div>
+								{% endif %}
+								<div class="four-column-information">
+									{% if ( fields['title_'~i] and link_url ) %}
+										<h5>
+											<a href="{{ link_url|e('esc_url') }}">{{ fields['title_'~i]|e('wp_kses_post')|raw }}</a>
+										</h5>
+									{% elseif ( fields['title_'~i] ) %}
+										<h5>{{ fields['title_'~i]|e('wp_kses_post')|raw }}</h5>
+									{% endif %}
+									{% if ( fields['description_'~i]  ) %}
+										<p>{{ fields['description_'~i]|e('wp_kses_post')|raw }}</p>
+									{% endif %}
+									{% if ( fields['link_text_'~i] ) %}
+										<a href="{{ link_url|e('esc_url') }}">
+											{{ fields['link_text_'~i]|e('wp_kses_post')|raw }}
+										</a>
+									{% endif %}
 								</div>
-							{% elseif (fields['attachment_'~i]) %}
-								<div class="four-column-symbol-container">
-									<img src="{{ fields['attachment_'~i] }}" alt="">
-								</div>
-							{% endif %}
-							<div class="four-column-information">
-								{% if ( fields['title_'~i] and link_url ) %}
-									<h5>
-										<a href="{{ link_url|e('esc_url') }}">{{ fields['title_'~i]|e('wp_kses_post')|raw }}</a>
-									</h5>
-								{% elseif ( fields['title_'~i] ) %}
-									<h5>{{ fields['title_'~i]|e('wp_kses_post')|raw }}</h5>
-								{% endif %}
-								{% if ( fields['description_'~i]  ) %}
-									<p>{{ fields['description_'~i]|e('wp_kses_post')|raw }}</p>
-								{% endif %}
-								{% if ( fields['link_text_'~i] ) %}
-									<a href="{{ link_url|e('esc_url') }}">
-										{{ fields['link_text_'~i]|e('wp_kses_post')|raw }}
-									</a>
-								{% endif %}
 							</div>
-						</div>
+						{% endif %}
 					{% endfor %}
 				</div>
 			</div>


### PR DESCRIPTION
The change here is that I wrapped the `four-column-wrap` column under an `if` statement to make sure we actually have content to display. 

As an example see the [About Us](https://dev.p4.greenpeace.org/international/about/) page, where we have content for 3 columns but we render 4, preventing the block from expanding to full width.