### PR TITLE
PLANET-1916 contentfourcolumn-update

### DIFF
--- a/classes/controller/blocks/class-contentfourcolumn-controller.php
+++ b/classes/controller/blocks/class-contentfourcolumn-controller.php
@@ -72,6 +72,33 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 				$fields = array_merge( $fields, $checkboxes );
 			}
 
+			$fields[] = [
+				'label'       => __( 'Number of Posts displayed', 'planet4-blocks' ),
+				'description' => __( 'Show 1 Row: Displays 4 Posts on desktop and 3 Posts on mobile.<br> 
+									Show 2 Rows: Displays 8 Posts on desktop and 6 Posts on mobile.<br>
+									(Another Row will be revealed each time the Load More button is clicked)<br>
+									Show All Rows: Displays all available Posts on desktop and 4 Posts on mobile.',
+									'planet4-blocks' ),
+				'attr'        => 'posts_view',
+				'type'        => 'select',
+				'options'     => [
+					[
+						'value' => '0',
+						// translators: placeholder is a number.
+						'label' => __( 'Show 1 Row', 'planet4-blocks' ),
+					],
+					[
+						'value' => '3',
+						// translators: placeholder is a number.
+						'label' => __( 'Show 2 Rows', 'planet4-blocks' ),
+					],
+					[
+						'value' => '1',
+						'label' => __( 'Show All Posts', 'planet4-blocks' ),
+					],
+				],
+			];
+
 			// Define the Shortcode UI arguments.
 			$shortcode_ui_args = [
 				'label'         => __( 'Content Four Column', 'planet4-blocks' ),
@@ -194,9 +221,10 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 			}
 
 			$block_data = [
-				'title'  => ! empty( $attributes['title'] ) ? $attributes['title'] : __( 'Publications', 'planet4-blocks' ),
-				'posts'  => $posts_array,
-				'domain' => 'planet4-blocks',
+				'title'      => ! empty( $attributes['title'] ) ? $attributes['title'] : __( 'Publications', 'planet4-blocks' ),
+				'posts'      => $posts_array,
+				'posts_view' => isset( $attributes['posts_view'] ) ? intval( $attributes['posts_view'] ) : 1,
+				'domain'     => 'planet4-blocks',
 			];
 
 			// Shortcode callbacks must return content, hence, output buffering here.

--- a/classes/controller/blocks/class-contentfourcolumn-controller.php
+++ b/classes/controller/blocks/class-contentfourcolumn-controller.php
@@ -84,12 +84,10 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 				'options'     => [
 					[
 						'value' => '0',
-						// translators: placeholder is a number.
 						'label' => __( 'Show 1 Row', 'planet4-blocks' ),
 					],
 					[
 						'value' => '3',
-						// translators: placeholder is a number.
 						'label' => __( 'Show 2 Rows', 'planet4-blocks' ),
 					],
 					[

--- a/includes/blocks/content_four_column.twig
+++ b/includes/blocks/content_four_column.twig
@@ -16,7 +16,7 @@
 				<h2 class="page-section-header">{{ title }}</h2>
 			{% endif %}
 
-			<div class="row limit-visibility">
+			<div class="row publications-slider limit-visibility">
 			{% for post in posts %}
 				<div class="col-md-4 col-lg-3 post-column">
 					<div class="four-column-content-wrap clearfix">

--- a/includes/blocks/content_four_column.twig
+++ b/includes/blocks/content_four_column.twig
@@ -9,9 +9,9 @@
 			{% endif %}
 
 			{% for post in posts %}
-				{% if loop.index0 == 0 %}
+				{% if ( loop.index0 == 0  or ( posts_view == 3 and loop.index0 == 4 ) or ( posts_view == 1 and loop.index0 is divisible by(4) ) ) %}
 					<div class="row publications-slider">
-				{% elseif loop.index0 is divisible by(4) %}
+				{% elseif ( ( ( posts_view == 0 and posts|length > 4 ) or ( posts_view == 3 and posts|length > 8) ) and loop.index0 is divisible by(4) ) %}
 					<div class="row row-hidden" id="publications-row-{{ loop.index }}" style="display: none;">
 				{% endif %}
 						<div class="col-md-4 col-lg">
@@ -58,11 +58,19 @@
 				{% endif %}
 			{% endfor %}
 
-			{% if ( posts|length > 4 ) %}
-				<div class="row mt-3 load-more-button-div">
+			{% if ( posts|length <= 4 or ( posts|length > 4 and posts|length <= 8 and posts_view == 3 ) or posts_view == 1 ) %}
+				<div class="row mt-3 load-more-posts-button-div">
+					<div class="col-md-4 col-lg-4 col-xl-3 mb-5 d-lg-none">
+						<button class="btn btn-block btn-medium btn-secondary btn-load-more-posts-click">
+							{{ __( 'Load More', domain ) }}
+						</button>
+					</div>
+				</div>
+			{% else %}
+				<div class="row mt-3 load-more-posts-button-div">
 					<div class="col-md-4 col-lg-4 col-xl-3 mb-5">
-						<button class="btn btn-block btn-medium btn-secondary btn-load-more-click">
-							{{ __( 'Load More', 'planet4-blocks' ) }}
+						<button class="btn btn-block btn-medium btn-secondary btn-load-more-posts-click">
+							{{ __( 'Load More', domain ) }}
 						</button>
 					</div>
 				</div>

--- a/includes/blocks/content_four_column.twig
+++ b/includes/blocks/content_four_column.twig
@@ -1,66 +1,61 @@
 {% block content_four_column %}
 
 {% if ( posts ) %}
-	<div class="four-column-content">
+	{% if ( posts_view == 0) %}
+		{% set posts_view_class = 'show-1-row' %}
+	{% elseif ( posts_view == 3) %}
+		{% set posts_view_class = 'show-2-rows' %}
+	{% else %}
+		{% set posts_view_class = 'show-all-rows' %}
+	{% endif %}
+
+	<div class="four-column-content {{ posts_view_class }}">
 		<div class="container">
 
 			{% if (title) %}
 				<h2 class="page-section-header">{{ title }}</h2>
 			{% endif %}
 
+			<div class="row limit-visibility">
 			{% for post in posts %}
-				{% if ( loop.index0 == 0  or ( posts_view == 3 and loop.index0 == 4 ) or ( posts_view == 1 and loop.index0 is divisible by(4) ) ) %}
-					<div class="row publications-slider">
-				{% elseif ( ( ( posts_view == 0 and posts|length > 4 ) or ( posts_view == 3 and posts|length > 8) ) and loop.index0 is divisible by(4) ) %}
-					<div class="row row-hidden" id="publications-row-{{ loop.index }}" style="display: none;">
-				{% endif %}
-						<div class="col-md-4 col-lg">
-							<div class="four-column-content-wrap clearfix">
-								<div class="four-column-content-info">
-									<div class="four-column-content-symbol">
-										{% if ( post.thumbnail ) %}
-											<a href="{{ post.permalink }}">
-												<img src="{{ post.thumbnail }}"
-													 alt="{{ post.alt_text }}"
-													 srcset="{{ post.srcset }}">
-										 </a>
-										{% endif %}
-									</div>
-									<div class="four-column-content-information">
-										{% if ( post.post_title ) %}
-											<a href="{{ post.permalink }}">
-												<h4>{{ post.post_title|e('wp_kses_post')|raw }}</h4>
-											</a>
-										{% endif %}
-										{% if ( post.post_date ) %}
-											<p class="publication-date">{{ post.post_date|date('F Y') }}</p>
-										{% endif %}
-										{% if ( post.post_excerpt ) %}
-											<p class="d-none d-md-block">{{ post.post_excerpt|truncate( 30, true )|e('wp_kses_post')|raw }}</p>
-										{% endif %}
-									</div>
-								</div>
+				<div class="col-md-4 col-lg-3 post-column">
+					<div class="four-column-content-wrap clearfix">
+						<div class="four-column-content-info">
+							<div class="four-column-content-symbol">
+								{% if ( post.thumbnail ) %}
+									<a href="{{ post.permalink }}">
+										<img src="{{ post.thumbnail }}"
+											 alt="{{ post.alt_text }}"
+											 srcset="{{ post.srcset }}">
+								 </a>
+								{% endif %}
+							</div>
+							<div class="four-column-content-information">
+								{% if ( post.post_title ) %}
+									<a href="{{ post.permalink }}">
+										<h4>{{ post.post_title|e('wp_kses_post')|raw }}</h4>
+									</a>
+								{% endif %}
+								{% if ( post.post_date ) %}
+									<p class="publication-date">{{ post.post_date|date('F Y') }}</p>
+								{% endif %}
+								{% if ( post.post_excerpt ) %}
+									<p class="d-none d-md-block">{{ post.post_excerpt|truncate( 30, true )|e('wp_kses_post')|raw }}</p>
+								{% endif %}
 							</div>
 						</div>
-				{% if ( (loop.index0 % 4 == 3)) %}
-				</div>
-				{% endif %}
-
-				{# note: add empty div columns based on remainder of the division of last row's columns and number 4
-				         to preserve row presentation (it is breaking because of slick slider,
-				         if number of columns are not 4). #}
-				{% if ( loop.last and (loop.index0 % 4 < 3)) %}
-					{% set empty_columns_count = 4 - (loop.index % 4) %}
-					{% for i in 1..empty_columns_count %}
-						<div class="col-md-4 col-lg-3 col-xl-3"></div>
-					{% endfor %}
 					</div>
-				{% endif %}
+				</div>
 			{% endfor %}
+			</div>
 
-			{% if ( posts|length <= 4 or ( posts|length > 4 and posts|length <= 8 and posts_view == 3 ) or posts_view == 1 ) %}
-				<div class="row mt-3 load-more-posts-button-div">
-					<div class="col-md-4 col-lg-4 col-xl-3 mb-5 d-lg-none">
+
+			{% if ( posts|length <= 4
+				or ( posts|length > 4 and posts|length <= 8 and posts_view == 3 )
+				or ( posts|length > 3 and posts|length <= 6 and posts_view == 3 )
+				or posts_view == 1 ) %}
+				<div class="row mt-3 load-more-posts-button-div" style="display: none;">
+					<div class="col-md-4 col-lg-3 col-xl-3 mb-5">
 						<button class="btn btn-block btn-medium btn-secondary btn-load-more-posts-click">
 							{{ __( 'Load More', domain ) }}
 						</button>
@@ -68,7 +63,7 @@
 				</div>
 			{% else %}
 				<div class="row mt-3 load-more-posts-button-div">
-					<div class="col-md-4 col-lg-4 col-xl-3 mb-5">
+					<div class="col-md-4 col-lg-3 col-xl-3 mb-5">
 						<button class="btn btn-block btn-medium btn-secondary btn-load-more-posts-click">
 							{{ __( 'Load More', domain ) }}
 						</button>


### PR DESCRIPTION
Add Selection of number of Rows for the Content Four Column Block. Editors can select 1, 2 or all rows of Posts to appear.

[Issue 1916](https://jira.greenpeace.org/browse/PLANET-1916)
Includes also [Issue 1974](https://jira.greenpeace.org/browse/PLANET-1974)