### PR TITLE
PLANET-2090 Allow html special chars for split two column tag name.

### DIFF
--- a/classes/controller/blocks/class-splittwocolumns-controller.php
+++ b/classes/controller/blocks/class-splittwocolumns-controller.php
@@ -257,7 +257,7 @@ if ( ! class_exists( 'SplitTwoColumns_Controller' ) ) {
 										wp_get_attachment_image_src( $campaign_image_id, 'full' )[0],
 										wp_get_attachment_metadata( $campaign_image_id ) ),
 					'image_alt'   => get_post_meta( $campaign_image_id, '_wp_attachment_image_alt', true ),
-					'name'        => $tag->name,
+					'name'        => html_entity_decode( $tag->name ),
 					'link'        => get_tag_link( $tag ),
 					'description' => $fields['tag_description'] ?? $tag->description,
 					'button_text' => $fields['button_text'] ?? __( 'Get Involved', 'planet4-blocks' ),


### PR DESCRIPTION
[Issue 2090](https://jira.greenpeace.org/browse/PLANET-2090)