### PR TITLE
PLANET-2261 - Use two circles for Take Action numbers

### DIFF
--- a/includes/blocks/tasks.twig
+++ b/includes/blocks/tasks.twig
@@ -22,7 +22,9 @@
 						{% for i in 1..4 %}
 							{% if ( fields['title_'~i] ) %}
 								<div class="col" data-id="{{ i }}">
-									<span class="step-number" id="step-{{ i }}">{{ i }}</span>
+									<span class="step-number" id="step-{{ i }}">
+										<span class="step-number-inner">{{ i }}</span>
+									</span>
 								</div>
 							{% endif %}
 						{% endfor %}


### PR DESCRIPTION
This a minor markup change needed by greenpeace/planet4-master-theme#499