### PR TITLE
PLANET-2372 Articles block- related article link consider current lan…

### DIFF
--- a/classes/controller/blocks/class-articles-controller.php
+++ b/classes/controller/blocks/class-articles-controller.php
@@ -120,7 +120,7 @@ if ( ! class_exists( 'Articles_Controller' ) ) {
 			// Read more button links to search results if no link is specified.
 			$tag_id          = $fields['tag_id'] ?? '';
 			$tag_filter      = $tag_id ? '&f[tag][' . get_tag( $tag_id )->name . ']=' . $tag_id : '';
-			$read_more_link  = ( ! empty( $fields['read_more_link'] ) ) ? $fields['read_more_link'] : get_site_url() . '/?s=&orderby=post_date&f[ctype][Post]=3' . $tag_filter;
+			$read_more_link  = ( ! empty( $fields['read_more_link'] ) ) ? $fields['read_more_link'] : get_home_url() . '/?s=&orderby=post_date&f[ctype][Post]=3' . $tag_filter;
 			$exclude_post_id = (int) ( $fields['exclude_post_id'] ?? '' );
 
 			// Get page categories.
@@ -287,7 +287,7 @@ if ( ! class_exists( 'Articles_Controller' ) ) {
 							's'                        => ' ',
 							'orderby'                  => 'relevant',
 							'f[ptype]['.$page_type.']' => $page_type_id,
-						], get_site_url()
+						], get_home_url()
 					);
 
 					$recent_posts[] = $recent;


### PR DESCRIPTION
…guage

The "Related articles" link in Articles block leads to search page. The `get_home_url()` function consider current page language in base url.

([Reference](https://wpml.org/wpml-hook/wpml_home_url/))