### PR TITLE
PLANET-2149 add enform block

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -51,8 +51,8 @@ if ( ! class_exists( 'Loader' ) ) {
 		private function __construct( $services = array(), $view_class ) {
 			$this->load_services( $services, $view_class );
 			$this->check_requirements();
-			add_action( 'plugins_loaded', array( $this, 'load_i18n' ) );
-			add_action( 'plugins_loaded', array( $this, 'load_external_services' ) );
+			add_action( 'plugins_loaded', [ $this, 'load_i18n' ] );
+			add_action( 'plugins_loaded', [ $this, 'load_external_services' ] );
 		}
 
 		/**
@@ -88,8 +88,8 @@ if ( ! class_exists( 'Loader' ) ) {
 		 * Hooks the plugin.
 		 */
 		private function hook_plugin() {
-			add_action( 'admin_menu',            array( $this, 'load_i18n' ) );
-			add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_assets' ) );
+			add_action( 'admin_menu',            [ $this, 'load_i18n' ] );
+			add_action( 'admin_enqueue_scripts', [ $this, 'load_admin_assets' ] );
 			// Provide hook for other plugins.
 			do_action( 'p4bks_plugin_loaded' );
 		}
@@ -127,10 +127,10 @@ if ( ! class_exists( 'Loader' ) ) {
 
 						$message .= '</div><br />';
 						wp_die(
-							$message, 'Plugin Requirements Error', array(
+							$message, 'Plugin Requirements Error', [
 								'response' => \WP_Http::OK,
 								'back_link' => true,
-							)
+							]
 						);
 					}
 				} else {
@@ -140,10 +140,10 @@ if ( ! class_exists( 'Loader' ) ) {
 						'<strong>' . esc_html__( 'PHP Requirements Error', 'planet4-blocks-backend' ) . '</strong><br /><br />' . esc_html( P4BKS_PLUGIN_NAME . __( ' requires a newer version of PHP.', 'planet4-blocks-backend' ) ) . '<br />' .
 						'<br/>' . esc_html__( 'Minimum required version of PHP: ', 'planet4-blocks-backend' ) . '<strong>' . esc_html( $this->required_php ) . '</strong>' .
 						'<br/>' . esc_html__( 'Running version of PHP: ', 'planet4-blocks-backend' ) . '<strong>' . esc_html( phpversion() ) . '</strong>' .
-						'</div>', 'Plugin Requirements Error', array(
+						'</div>', 'Plugin Requirements Error', [
 							'response' => \WP_Http::OK,
 							'back_link' => true,
-						)
+						]
 					);
 				}
 			}
@@ -226,9 +226,9 @@ if ( ! class_exists( 'Loader' ) ) {
 	wp_die(
 		'<div class="error fade">' .
 		'<u>' . esc_html( P4BKS_PLUGIN_NAME ) . esc_html__( 'Conflict Error', 'planet4-blocks-backend' ) . '</u><br /><br />' . esc_html__( 'Class P4BKS_Loader already exists.', 'planet4-blocks-backend' ) . '<br />' .
-		'</div>', 'Plugin Conflict Error', array(
+		'</div>', 'Plugin Conflict Error', [
 			'response' => \WP_Http::OK,
 			'back_link' => true,
-		)
+		]
 	);
 }

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'Loader' ) ) {
 		 * Loads all shortcake blocks registered outside of this plugin.
 		 */
 		public function load_external_services() {
-			$this->external_services = apply_filters( 'p4bks_pre_load_services', $this->external_services );
+			$this->external_services = apply_filters( 'p4bks_add_external_services', $this->external_services );
 			if ( $this->external_services ) {
 				foreach ( $this->external_services as $service ) {
 					( new $service( $this->view ) )->load();

--- a/classes/view/class-view.php
+++ b/classes/view/class-view.php
@@ -27,13 +27,13 @@ if ( ! class_exists( 'View' ) ) {
 		 *
 		 * @param array|string $template_name The file name of the template to render.
 		 * @param array        $data The data to pass to the template.
-		 * @param string       $sub_dir The path to a subdirectory where the template is located (relative to $template_dir).
+		 * @param string       $relevant_dir The path to a subdirectory where the template is located (relative to $template_dir).
 		 *
 		 * @return bool|string The returned output
 		 */
-		public function get_template( $template_name, $data, $sub_dir = 'blocks/' ) {
+		public function get_template( $template_name, $data, $relevant_dir = 'blocks/' ) {
 			Timber::$locations = $this->template_dir;
-			return Timber::compile( [ $sub_dir . $template_name . '.twig' ], $data );
+			return Timber::compile( [ $relevant_dir . $template_name . '.twig' ], $data );
 		}
 
 		/**
@@ -41,11 +41,11 @@ if ( ! class_exists( 'View' ) ) {
 		 *
 		 * @param array|string $template_name The file name of the template to render.
 		 * @param array        $data The data to pass to the template.
-		 * @param string       $sub_dir The path to a subdirectory where the template is located (relative to $template_dir).
+		 * @param string       $relevant_dir The path to a subdirectory where the template is located (relative to $template_dir).
 		 */
-		private function view_template( $template_name, $data, $sub_dir = '' ) {
+		private function view_template( $template_name, $data, $relevant_dir = '' ) {
 			Timber::$locations = $this->template_dir;
-			Timber::render( [ $sub_dir . $template_name . '.twig' ], $data );
+			Timber::render( [ $relevant_dir . $template_name . '.twig' ], $data );
 		}
 
 		/**
@@ -63,15 +63,15 @@ if ( ! class_exists( 'View' ) ) {
 		 * @param array|string $template_name The file name of the template to render.
 		 * @param array        $data The data to pass to the template.
 		 * @param string       $template_ext The extension of the template (php, twig, ...).
-		 * @param string       $sub_dir The path to a subdirectory where the template is located (relative to $template_dir).
+		 * @param string       $relevant_dir The path to a subdirectory where the template is located (relative to $template_dir).
 		 */
-		public function block( $template_name, $data, $template_ext = 'twig', $sub_dir = 'blocks/' ) {
+		public function block( $template_name, $data, $template_ext = 'twig', $relevant_dir = 'blocks/' ) {
 
 			if ( 'twig' === $template_ext ) {
 				Timber::$locations = $this->template_dir;
-				Timber::render( [ $sub_dir . $template_name . '.' . $template_ext ], $data );
+				Timber::render( [ $relevant_dir . $template_name . '.' . $template_ext ], $data );
 			} else {
-				include_once $this->template_dir . $sub_dir . $template_name . '.' . $template_ext;
+				include_once $this->template_dir . $relevant_dir . $template_name . '.' . $template_ext;
 			}
 		}
 	}


### PR DESCRIPTION
Allow registration of a shortcake block from outside of this plugin. The external blocks are registered after all plugins are loaded. Renamed View argument to make more sense.

related to this [PR](https://github.com/greenpeace/planet4-plugin-engagingnetworks/pull/21)
