### PR TITLE
PLANET-2426 covers smaller images

### DIFF
--- a/classes/controller/blocks/class-covers-controllers.php
+++ b/classes/controller/blocks/class-covers-controllers.php
@@ -157,7 +157,7 @@ if ( ! class_exists( 'Covers_Controller' ) ) {
 						'tags'        => $tags,
 						'title'       => get_the_title( $action ),
 						'excerpt'     => get_the_excerpt( $action ),    // Note: WordPress removes shortcodes from auto-generated excerpts.
-						'image'       => get_the_post_thumbnail_url( $action ),
+						'image'       => get_the_post_thumbnail_url( $action, 'large' ),
 						'button_text' => $cover_button_text,
 						'button_link' => get_permalink( $action->ID ),
 					];


### PR DESCRIPTION
Use 'large' size background images for take action covers in Covers block, instead of using unecessarily the full sizes image.