### PR TITLE
PLANET-2547 blocks more testable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This WordPress plugin provides the necessary blocks to be used with Shortcake UI
 
 1. Create a new controller class that extends Controller inside directory _classes/controller/blocks_. The class name should follow naming convention, for example **Blockname**_Controller and its file name should be class-**blockname**-controller.php. 
 
-2. Implement its parent's class two abstract methods. In method **prepare_fields()** you need to define the blocks fields and in method **prepare_template()** you need to prepare them for rendering.
+2. Implement its parent's class two abstract methods. In method **prepare_fields()** you need to define the blocks fields and in method **prepare_data()** you need to prepare the data which will be used for rendering.
 
 3. Create the template file that will be used to render your block inside directory _includes/blocks_. If the name of the file is **blockname**.twig then
 you need to set the BLOCK_NAME constant as **'blockname'** It also works with html templates. Just add 'php' as the 3rd argument of the block() method.

--- a/classes/controller/blocks/class-campaignthumbnail-controller.php
+++ b/classes/controller/blocks/class-campaignthumbnail-controller.php
@@ -43,18 +43,15 @@ if ( ! class_exists( 'CampaignThumbnail_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields This contains array of all data added.
+		 * @param array  $fields This contains array of article shortcake block field.
 		 * @param string $content This is the post content.
-		 * @param string $shortcode_tag The shortcode block of campaign thumbnail.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @since 0.1.0
-		 *
-		 * @return string All the data used for the html.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 
 			// If $fields['category_id'] exists then we are on Campaign Page, else we are on Issue Page.
 			if ( ! empty( $fields['category_id'] ) ) {
@@ -64,10 +61,10 @@ if ( ! class_exists( 'CampaignThumbnail_Controller' ) ) {
 				$parent_id        = $options['explore_page'];
 				$explore_children = [];
 
-				if( 0 !== absint( $parent_id ) ) {
+				if ( 0 !== absint( $parent_id ) ) {
 					$args = [
 						'post_type'      => 'page',
-						'post_parent'    => $parent_id
+						'post_parent'    => $parent_id,
 					];
 					$explore_children = get_children( $args );
 				}
@@ -140,12 +137,7 @@ if ( ! class_exists( 'CampaignThumbnail_Controller' ) ) {
 			$data = [
 				'fields' => $fields,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering	here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-carousel-controller.php
+++ b/classes/controller/blocks/class-carousel-controller.php
@@ -98,18 +98,15 @@ if ( ! class_exists( 'Carousel_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields        This contains array of multiple image field.
-		 * @param string $content       This is the post content.
-		 * @param string $shortcode_tag The shortcode block of carousel.
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @since 0.1.0
-		 *
-		 * @return string All the data used for the html.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ): string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 
 			$explode_multiple_image_array = explode( ',', $fields['multiple_image'] );
 			$images_data                  = array();
@@ -149,12 +146,7 @@ if ( ! class_exists( 'Carousel_Controller' ) ) {
 				'title'  => $carousel_title,
 				'images' => $images,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 
 		/**

--- a/classes/controller/blocks/class-carouselheader-controller.php
+++ b/classes/controller/blocks/class-carouselheader-controller.php
@@ -124,16 +124,15 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for carousel header shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $attributes    Defined attributes array for this shortcode.
-		 * @param string $content       Content.
-		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param array  $attributes This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string Returns the compiled template.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
+		public function prepare_data( $attributes, $content, $shortcode_tag ) : array {
 
 			$attributes_temp = [];
 			for ( $i = 1; $i < 5; $i++ ) {
@@ -152,7 +151,7 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 
 			$total_images = 0;
 			for ( $i = 1; $i < 5; $i++ ) {
-				if ( array_key_exists("image_$i", $attributes ) ) {
+				if ( array_key_exists( "image_$i", $attributes ) ) {
 					$image_id   = $attributes[ "image_$i" ];
 					$temp_array = wp_get_attachment_image_src( $image_id, 'retina-large' );
 					if ( false !== $temp_array && ! empty( $temp_array ) ) {
@@ -170,12 +169,7 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 			$block_data = [
 				'fields' => $attributes,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $block_data );
-
-			return ob_get_clean();
+			return $block_data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-carouselsplit-controller.php
+++ b/classes/controller/blocks/class-carouselsplit-controller.php
@@ -48,16 +48,15 @@ if ( ! class_exists( 'CarouselSplit_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the carousel split shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $attributes    Defined  attributes array for this shortcode.
-		 * @param string $content       Content.
-		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param array  $attributes This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string Returns the compiled template.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
+		public function prepare_data( $attributes, $content, $shortcode_tag ) : array {
 
 			$images          = [];
 			$multiple_images = $attributes['multiple_images'] ?? '';
@@ -82,14 +81,9 @@ if ( ! class_exists( 'CarouselSplit_Controller' ) ) {
 			}
 
 			$block_data = [
-				'fields'              => $images,
+				'fields' => $images,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $block_data );
-
-			return ob_get_clean();
+			return $block_data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-contentfourcolumn-controller.php
+++ b/classes/controller/blocks/class-contentfourcolumn-controller.php
@@ -109,16 +109,15 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for content four column shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $attributes Defined attributes array for this shortcode.
-		 * @param string $content Content.
-		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param array  $attributes This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string Returns the compiled template.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
+		public function prepare_data( $attributes, $content, $shortcode_tag ) : array {
 
 			$raw_tags   = $attributes['select_tag'] ?? '';
 			$post_types = [];
@@ -223,12 +222,7 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 				'posts'      => $posts_array,
 				'posts_view' => isset( $attributes['posts_view'] ) ? intval( $attributes['posts_view'] ) : 1,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $block_data );
-
-			return ob_get_clean();
+			return $block_data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-contentthreecolumn-controller.php
+++ b/classes/controller/blocks/class-contentthreecolumn-controller.php
@@ -77,18 +77,15 @@ if ( ! class_exists( 'ContentThreeColumn_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields This contains array of all data added.
+		 * @param array  $fields This contains array of article shortcake block field.
 		 * @param string $content This is the post content.
-		 * @param string $shortcode_tag The shortcode block of three column.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @since 0.1.0
-		 *
-		 * @return string All the data used for the html.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 
 			for ( $i = 1; $i < 4; $i++ ) {
 				$img_array = wp_get_attachment_image_src( $fields[ "image_$i" ], 'medium_large' );
@@ -101,12 +98,7 @@ if ( ! class_exists( 'ContentThreeColumn_Controller' ) ) {
 			$data = [
 				'fields' => $fields,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-controller.php
+++ b/classes/controller/blocks/class-controller.php
@@ -116,6 +116,37 @@ if ( ! class_exists( 'Controller' ) ) {
 		abstract public function prepare_fields();
 
 		/**
+		 * Get all the data that will be needed to render the block correctly.
+		 *
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
+		 *
+		 * @return array The data to be passed in the View.
+		 */
+		abstract public function prepare_data( $fields, $content, $shortcode_tag ) : array;
+
+		/**
+		 * Callback for the shortcode.
+		 * It renders the shortcode based on supplied attributes.
+		 *
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @return string All the data used for the html.
+		 */
+		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+			$data = $this->prepare_data( $fields, $content, $shortcode_tag );
+			// Shortcode callbacks must return content, hence, output buffering here.
+			ob_start();
+			$this->view->block( static::BLOCK_NAME, $data );
+			return ob_get_clean();
+		}
+
+		/**
 		 * Output markup of an iframe to render shortcode when previewing in admin edit screen.
 		 *
 		 * We need to load through iframe to enqueue frontend styles without breaking admin ui
@@ -207,17 +238,5 @@ if ( ! class_exists( 'Controller' ) ) {
 			// Ajax callbacks need to call exit.
 			exit;
 		}
-
-		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
-		 *
-		 * @param array  $fields         Associative array of shortcode paramaters.
-		 * @param string $content        The content of the shortcode block for content wrapper shortcodes only.
-		 * @param string $shortcode_tag  The name of the shortcode.
-		 *
-		 * @return string                The html markup for the shortcode preview iframe
-		 */
-		abstract public function prepare_template( $fields, $content, $shortcode_tag ) : string;
 	}
 }

--- a/classes/controller/blocks/class-cookies-controller.php
+++ b/classes/controller/blocks/class-cookies-controller.php
@@ -78,16 +78,15 @@ if ( ! class_exists( 'Cookies_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for cookies shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array $attributes Defined attributes array for this shortcode.
-		 * @param string $content Content.
-		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param array  $attributes This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string Returns the compiled template.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $attributes, $content, $shortcode_tag ): string {
+		public function prepare_data( $attributes, $content, $shortcode_tag ) : array {
 			wp_enqueue_script( 'cookies', P4BKS_ADMIN_DIR . 'js/cookies.js' );
 
 			$block_data = [
@@ -100,12 +99,7 @@ if ( ! class_exists( 'Cookies_Controller' ) ) {
 					'all_cookies_description'       => $attributes['all_cookies_description'] ?? '',
 				],
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $block_data );
-
-			return ob_get_clean();
+			return $block_data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-covers-controllers.php
+++ b/classes/controller/blocks/class-covers-controllers.php
@@ -102,16 +102,15 @@ if ( ! class_exists( 'Covers_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields Array of fields that are to be used in the template.
-		 * @param string $content The content of the post.
-		 * @param string $shortcode_tag The shortcode tag.
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 			$select_tags = $fields['select_tag'] ?? '';
 
 			$options       = get_option( 'planet4_options' );
@@ -172,11 +171,7 @@ if ( ! class_exists( 'Covers_Controller' ) ) {
 				'covers'      => $covers,
 				'covers_view' => $covers_view,
 			];
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-happypoint-controller.php
+++ b/classes/controller/blocks/class-happypoint-controller.php
@@ -127,7 +127,6 @@ if ( ! class_exists( 'HappyPoint_Controller' ) ) {
 				'iframe_url'          => $fields['iframe_url'] ?? '',
 			];
 
-			$shortcode_tag = 'shortcake_' . self::BLOCK_NAME;
 			$fields = shortcode_atts( $shortcode_atts_pairs, $fields, $shortcode_tag );
 
 			if ( ! is_numeric( $fields['opacity'] ) ) {
@@ -150,12 +149,7 @@ if ( ! class_exists( 'HappyPoint_Controller' ) ) {
 			$data = [
 				'fields' => $fields,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-happypoint-controller.php
+++ b/classes/controller/blocks/class-happypoint-controller.php
@@ -75,7 +75,9 @@ if ( ! class_exists( 'HappyPoint_Controller' ) ) {
 					'label' => __( '<i>We use an overlay to fade the image back. Use a number between 1 and 100,<br /> the higher the number, the more faded the image will look. If you leave this <br/> empty, the default of 30 will be used.</i>', 'planet4-blocks-backend' ),
 					'attr'  => 'opacity',
 					'type'  => 'number',
-					'meta'  => [ 'data-test' => 30 ],
+					'meta'  => [
+						'data-test' => 30,
+					],
 				],
 				[
 					'label' => __( 'Use mailing list iframe', 'planet4-blocks-backend' ),
@@ -107,25 +109,25 @@ if ( ! class_exists( 'HappyPoint_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcake_twocolumn shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields Array of fields that are to be used in the template.
-		 * @param string $content The content of the post.
-		 * @param string $shortcode_tag The shortcode tag (shortcake_blockname).
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string The complete html of the block
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 
 			$shortcode_atts_pairs = [
 				'background'          => '',
 				'opacity'             => 30,
-				'focus_image'         => $attributes['focus_image'] ?? 'center center',
+				'focus_image'         => $fields['focus_image'] ?? 'center center',
 				'mailing_list_iframe' => '',
-				'iframe_url'          => $attributes['iframe_url'] ?? '',
+				'iframe_url'          => $fields['iframe_url'] ?? '',
 			];
 
+			$shortcode_tag = 'shortcake_' . self::BLOCK_NAME;
 			$fields = shortcode_atts( $shortcode_atts_pairs, $fields, $shortcode_tag );
 
 			if ( ! is_numeric( $fields['opacity'] ) ) {

--- a/classes/controller/blocks/class-mediablock-controller.php
+++ b/classes/controller/blocks/class-mediablock-controller.php
@@ -48,16 +48,15 @@ if ( ! class_exists( 'MediaBlock_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the tasks shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $attributes    Defined attributes array for this shortcode.
-		 * @param string $content       Content.
-		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param array  $attributes This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string Returns the compiled template.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
+		public function prepare_data( $attributes, $content, $shortcode_tag ) : array {
 
 			$image_id           = $attributes['attachment'];
 			$image              = wp_get_attachment_image_src( $image_id , 'full' );
@@ -75,12 +74,7 @@ if ( ! class_exists( 'MediaBlock_Controller' ) ) {
 			$block_data = [
 				'fields' => $fields,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $block_data );
-
-			return ob_get_clean();
+			return $block_data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-mediavideo-controller.php
+++ b/classes/controller/blocks/class-mediavideo-controller.php
@@ -53,28 +53,20 @@ if ( ! class_exists( 'MediaVideo_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields This contains array of all data added.
+		 * @param array  $fields This contains array of article shortcake block field.
 		 * @param string $content This is the post content.
-		 * @param string $shortcode_tag The shortcode block of mediavideo.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @since 0.1.0
-		 *
-		 * @return string All the data used for the html.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 
 			$data = [
 				'fields' => $fields,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-splittwocolumns-controller.php
+++ b/classes/controller/blocks/class-splittwocolumns-controller.php
@@ -217,16 +217,15 @@ if ( ! class_exists( 'SplitTwoColumns_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields Array of fields that are to be used in the template.
-		 * @param string $content The content of the post.
-		 * @param string $shortcode_tag The shortcode tag.
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 			$issue_id        = absint( $fields['select_issue'] );
 			$issue_meta_data = get_post_meta( $issue_id );
 
@@ -263,12 +262,7 @@ if ( ! class_exists( 'SplitTwoColumns_Controller' ) ) {
 					'focus'       => $fields['focus_tag_image'] ?? '',
 				],
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-staticfourcolumn-controller.php
+++ b/classes/controller/blocks/class-staticfourcolumn-controller.php
@@ -104,16 +104,15 @@ if ( ! class_exists( 'StaticFourColumn_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for static four column shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $attributes    Defined attributes array for this shortcode.
-		 * @param string $content       Content.
-		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param array  $attributes This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string Returns the compiled template.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
+		public function prepare_data( $attributes, $content, $shortcode_tag ) : array {
 
 			$title           = $attributes['title'] ?? '';
 			$attributes_temp = [];
@@ -127,6 +126,7 @@ if ( ! class_exists( 'StaticFourColumn_Controller' ) ) {
 				];
 				$attributes_temp = array_merge( $attributes_temp, $temp_array );
 			}
+			$shortcode_tag = 'shortcake_' . self::BLOCK_NAME;
 			$attributes = shortcode_atts( $attributes_temp, $attributes, $shortcode_tag );
 
 			for ( $i = 1; $i < 5; $i++ ) {
@@ -141,12 +141,7 @@ if ( ! class_exists( 'StaticFourColumn_Controller' ) ) {
 				'fields'              => $attributes,
 				'available_languages' => P4BKS_LANGUAGES,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $block_data );
-
-			return ob_get_clean();
+			return $block_data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-staticfourcolumn-controller.php
+++ b/classes/controller/blocks/class-staticfourcolumn-controller.php
@@ -126,7 +126,6 @@ if ( ! class_exists( 'StaticFourColumn_Controller' ) ) {
 				];
 				$attributes_temp = array_merge( $attributes_temp, $temp_array );
 			}
-			$shortcode_tag = 'shortcake_' . self::BLOCK_NAME;
 			$attributes = shortcode_atts( $attributes_temp, $attributes, $shortcode_tag );
 
 			for ( $i = 1; $i < 5; $i++ ) {

--- a/classes/controller/blocks/class-subheader-controller.php
+++ b/classes/controller/blocks/class-subheader-controller.php
@@ -44,17 +44,17 @@ if ( ! class_exists( 'Subheader_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcake_twocolumn shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields Array of fields that are to be used in the template.
-		 * @param string $content The content of the post.
-		 * @param string $shortcode_tag The shortcode tag (shortcake_blockname).
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string The complete html of the block
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 
+			$shortcode_tag = 'shortcake_' . self::BLOCK_NAME;
 			$fields = shortcode_atts( array(
 				'title'       => '',
 				'description' => '',
@@ -63,12 +63,7 @@ if ( ! class_exists( 'Subheader_Controller' ) ) {
 			$data = [
 				'fields' => $fields,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-subheader-controller.php
+++ b/classes/controller/blocks/class-subheader-controller.php
@@ -54,7 +54,6 @@ if ( ! class_exists( 'Subheader_Controller' ) ) {
 		 */
 		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 
-			$shortcode_tag = 'shortcake_' . self::BLOCK_NAME;
 			$fields = shortcode_atts( array(
 				'title'       => '',
 				'description' => '',

--- a/classes/controller/blocks/class-submenu-controller.php
+++ b/classes/controller/blocks/class-submenu-controller.php
@@ -171,16 +171,15 @@ if ( ! class_exists( 'SubMenu_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for submenu shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $attributes    Defined attributes array for this shortcode.
-		 * @param string $content       Content.
-		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param array  $attributes This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string Returns the compiled template.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
+		public function prepare_data( $attributes, $content, $shortcode_tag ) : array {
 
 			global $post;
 
@@ -200,12 +199,7 @@ if ( ! class_exists( 'SubMenu_Controller' ) ) {
 				'menu'  => $menu,
 				'style' => $attributes['submenu_style'] ?? '1',
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $block_data );
-
-			return ob_get_clean();
+			return $block_data;
 		}
 
 		/**

--- a/classes/controller/blocks/class-takeactionboxout-controller.php
+++ b/classes/controller/blocks/class-takeactionboxout-controller.php
@@ -73,16 +73,15 @@ if ( ! class_exists( 'TakeActionBoxout_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields Array of fields that are to be used in the template.
-		 * @param string $content The content of the post.
-		 * @param string $shortcode_tag The shortcode tag.
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 			$page_id = $fields['take_action_page'] ?? '';
 
 			$args = [
@@ -127,12 +126,7 @@ if ( ! class_exists( 'TakeActionBoxout_Controller' ) ) {
 			$data = [
 				'boxout' => $block,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-tasks-controller.php
+++ b/classes/controller/blocks/class-tasks-controller.php
@@ -151,7 +151,6 @@ if ( ! class_exists( 'Tasks_Controller' ) ) {
 				];
 				$attributes_temp = array_merge( $attributes_temp, $temp_array );
 			}
-			$shortcode_tag = 'shortcake_' . self::BLOCK_NAME;
 			$attributes = shortcode_atts( $attributes_temp, $attributes, $shortcode_tag );
 
 			for ( $i = 1; $i < 5; $i++ ) {

--- a/classes/controller/blocks/class-tasks-controller.php
+++ b/classes/controller/blocks/class-tasks-controller.php
@@ -127,16 +127,15 @@ if ( ! class_exists( 'Tasks_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the tasks shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $attributes    Defined attributes array for this shortcode.
-		 * @param string $content       Content.
-		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param array  $attributes This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string Returns the compiled template.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $attributes, $content, $shortcode_tag ) : string {
+		public function prepare_data( $attributes, $content, $shortcode_tag ) : array {
 
 			$attributes_temp = [
 				'tasks_title'        => $attributes['tasks_title'] ?? '',
@@ -152,6 +151,7 @@ if ( ! class_exists( 'Tasks_Controller' ) ) {
 				];
 				$attributes_temp = array_merge( $attributes_temp, $temp_array );
 			}
+			$shortcode_tag = 'shortcake_' . self::BLOCK_NAME;
 			$attributes = shortcode_atts( $attributes_temp, $attributes, $shortcode_tag );
 
 			for ( $i = 1; $i < 5; $i++ ) {
@@ -165,12 +165,7 @@ if ( ! class_exists( 'Tasks_Controller' ) ) {
 				'fields'              => $attributes,
 				'available_languages' => P4BKS_LANGUAGES,
 			];
-
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $block_data );
-
-			return ob_get_clean();
+			return $block_data;
 		}
 	}
 }

--- a/classes/controller/blocks/class-twocolumn-controller.php
+++ b/classes/controller/blocks/class-twocolumn-controller.php
@@ -140,25 +140,20 @@ if ( ! class_exists( 'TwoColumn_Controller' ) ) {
 		}
 
 		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
+		 * Get all the data that will be needed to render the block correctly.
 		 *
-		 * @param array  $fields Array of fields that are to be used in the template.
-		 * @param string $content The content of the post.
-		 * @param string $shortcode_tag The shortcode tag (shortcake_two_columns).
+		 * @param array  $fields This contains array of article shortcake block field.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode block of article.
 		 *
-		 * @return string The html markup for the block.
+		 * @return array The data to be passed in the View.
 		 */
-		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
 
 			$data = [
 				'fields' => $fields,
 			];
-			// Shortcode callbacks must return content, hence, output buffering here.
-			ob_start();
-			$this->view->block( self::BLOCK_NAME, $data );
-
-			return ob_get_clean();
+			return $data;
 		}
 	}
 }


### PR DESCRIPTION
Refactor main controller class and abstract methods to make blocks more Unit testable. Separated concerns for the prepare_template method and moved logic for preparing data into the prepare_data method. This way we can unit test this logic without testing the rendering of the block at the same time. Updated readme file.

Issue [2547](https://jira.greenpeace.org/browse/PLANET-2547)
Related with #319 