### PR TITLE
PLANET - no issue: Fix TinyMCE disappearing from Post edit

### DIFF
--- a/classes/controller/blocks/class-controller.php
+++ b/classes/controller/blocks/class-controller.php
@@ -264,9 +264,7 @@ if ( ! class_exists( 'Controller' ) ) {
 
 			$template = P4BKS_PLUGIN_DIR . '/admin/templates/' . $template . '.tpl.php';
 			if ( file_exists( $template ) ) {
-				global $wp_filesystem;
-
-				$contents = $wp_filesystem->get_contents( $template );
+				$contents = file_get_contents( $template );
 
 				return false !== $contents ? $contents : '';
 			}


### PR DESCRIPTION
Editor disappeared from Post Edit page. Looks like the `wp_filesystem` call is causing the problem.

I just restored the original version, feel free to change it if you find a better method.

Screenshot:
![image](https://user-images.githubusercontent.com/340766/48016010-38e09e00-e109-11e8-8844-6e219158c933.png)
