### PR TITLE
PLANET-2739 - Fix Carousel Header Controller

### DIFF
--- a/classes/controller/blocks/class-carousel-controller.php
+++ b/classes/controller/blocks/class-carousel-controller.php
@@ -121,6 +121,8 @@ if ( ! class_exists( 'Carousel_Controller' ) ) {
 			$images_data                  = [];
 
 			$images_dimensions = [];
+			$images[]          = $images_data;
+
 			foreach ( $explode_multiple_image_array as $image_id ) {
 
 				$image_data_array            = wp_get_attachment_image_src( $image_id, 'retina-large' );
@@ -139,12 +141,10 @@ if ( ! class_exists( 'Carousel_Controller' ) ) {
 
 				$images_data['caption'] = wp_get_attachment_caption( $image_id );
 
-				if ( count( $image_data_array ) >= 3 ) {
+				if ( count( (array) $image_data_array ) >= 3 ) {
 					$images_dimensions[] = $image_data_array[1];
 					$images_dimensions[] = $image_data_array[2];
 				}
-
-				$images[] = $images_data;
 			}
 
 			$carousel_title = ( isset( $fields['carousel_block_title'] ) && ! empty( $fields['carousel_block_title'] ) ) ? $fields['carousel_block_title'] : '';

--- a/tests/unit/test-carousel.php
+++ b/tests/unit/test-carousel.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'P4_CarouselTest' ) ) {
 			$data   = $this->block->prepare_data( $fields );
 
 			try {
-				$this->assertEquals( self::ATTACHMENTS_COUNT, count( $data['images'] ) );
+				$this->assertEquals( self::ATTACHMENTS_COUNT, count( (array) $data['images'] ) );
 			} catch ( \Exception $e ) {
 				$this->fail( '->Did not find as many Attachments as expected.' );
 			}


### PR DESCRIPTION
I moved the `$images` initialization outside the loop, which seems more logical, and type casted to array to stop `count()` from complaining.

This fixes the error we had (`php count(): Parameter must be an array or an object that implements Countable`).

We still have an [error](https://circleci.com/gh/greenpeace/planet4-plugin-blocks/702) the Carousel unit test, but we have it on all php environments, so not sure if it's relevant to this.
```
P4_CarouselTest::test_attachments_count
->Did not find as many Attachments as expected.

/home/circleci/project/tests/unit/test-carousel.php:53
```

Thanks @angtheod for help! :beers: 