### PR TITLE
PLANET-2874 Ignore sniff error for nonce verification

### DIFF
--- a/classes/controller/blocks/class-controller.php
+++ b/classes/controller/blocks/class-controller.php
@@ -108,8 +108,8 @@ if ( ! class_exists( 'Controller' ) ) {
 				wp_doing_ajax()
 				&& is_user_logged_in()
 				&& wp_get_current_user()->has_cap( 'edit_posts' )
-				&& isset( $_REQUEST['action'] )
-				&& 'bulk_do_shortcode' === $_REQUEST['action']
+				&& isset( $_REQUEST['action'] ) // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+				&& 'bulk_do_shortcode' === $_REQUEST['action']  // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			) {
 				// Render a preview iframe using a wrapper method.
 				add_shortcode( 'shortcake_' . static::BLOCK_NAME, [ $this, 'prepare_template_preview_iframe' ] );


### PR DESCRIPTION
Add an ignore as the nonce verification is not really needed. 
There are user & capability checks before and it's only a read request.