### PR TITLE
Fix of phpunits testing according to bellow link

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ job-references:
     name: "Install Dependencies"
     command: |
       sudo apt-get update && sudo apt-get install subversion
-      sudo docker-php-ext-install mysqli
+      sudo -E docker-php-ext-install mysqli
       sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
       sudo apt-get update && sudo apt-get install mysql-client-5.7
 


### PR DESCRIPTION
https://discuss.circleci.com/t/usr-local-bin-docker-php-ext-enable-108-usr-local-bin-docker-php-ext-enable-cannot-create-conf-d-docker-php-ext-mysqli-ini-directory-nonexistent/26560/2