### PR TITLE
PLANET-2929: Covers block: Load More button has an ellipsis

### DIFF
--- a/classes/controller/blocks/class-covers-controller.php
+++ b/classes/controller/blocks/class-covers-controller.php
@@ -170,7 +170,7 @@ if ( ! class_exists( 'Covers_Controller' ) ) {
 						'button_link' => get_permalink( $action->ID ),
 					];
 				}
-				$fields['button_text'] = __( 'Load More ...', 'planet4-blocks' );
+				$fields['button_text'] = __( 'Load More', 'planet4-blocks' );
 			}
 
 			$covers_view = isset( $fields['covers_view'] ) ? intval( $fields['covers_view'] ) : 1;

--- a/classes/controller/blocks/class-newcovers-controller.php
+++ b/classes/controller/blocks/class-newcovers-controller.php
@@ -491,7 +491,7 @@ if ( ! class_exists( 'NewCovers_Controller' ) ) {
 						'button_link' => get_permalink( $action->ID ),
 					];
 				}
-				$fields['button_text'] = __( 'Load More ...', 'planet4-blocks' );
+				$fields['button_text'] = __( 'Load More', 'planet4-blocks' );
 			}
 
 			return $covers;

--- a/planet4-blocks.php
+++ b/planet4-blocks.php
@@ -138,7 +138,7 @@ function plugin_blocks_report_view() {
 /**
  * Filters array elements on being a shortcake shortcode
  *
- * @param $shortcode
+ * @param string $shortcode The shortcode.
  * @return bool
  */
 function is_shortcake( $shortcode ) {
@@ -153,8 +153,8 @@ function is_shortcake( $shortcode ) {
  */
 function plugin_blocks_report() {
 	global $wpdb, $shortcode_tags;
-	
-	//	Array filtering on shortcake shortcodes
+
+	// Array filtering on shortcake shortcodes.
 	$blocks = array_filter( array_keys( $shortcode_tags ), 'is_shortcake' );
 
 	// phpcs:disable
@@ -168,7 +168,7 @@ function plugin_blocks_report() {
 
 		$results = $wpdb->get_results( $sql );
 
-		//Confusion between old and new covers.
+		// Confusion between old and new covers.
 		if ( 'covers' == $block ) {
 			$block = 'Take Action Covers - Old block';
 		}


### PR DESCRIPTION
Some texts had a hardcoded ellipsis. 

@kirdia @koyan  ⚠️ I guess this will need some updates to the PO files. 

Ref: https://jira.greenpeace.org/browse/PLANET-2929