### PR TITLE
PLANET-2910 - Covers block - Updated the default sort order behavior

### DIFF
--- a/classes/controller/blocks/class-covers-controller.php
+++ b/classes/controller/blocks/class-covers-controller.php
@@ -130,8 +130,11 @@ if ( ! class_exists( 'Covers_Controller' ) ) {
 					'post_type'        => 'page',
 					'post_status'      => 'publish',
 					'post_parent'      => $parent_act_id,
-					'orderby'          => 'menu_order',
-					'order'            => 'ASC',
+					'orderby'          => [
+						'menu_order' => 'ASC',
+						'date'       => 'DESC',
+						'title'      => 'ASC',
+					],
 					'suppress_filters' => false,
 					'numberposts'      => P4BKS_COVERS_NUM,
 				];

--- a/classes/controller/blocks/class-newcovers-controller.php
+++ b/classes/controller/blocks/class-newcovers-controller.php
@@ -275,8 +275,11 @@ if ( ! class_exists( 'NewCovers_Controller' ) ) {
 					'post_type'        => 'page',
 					'post_status'      => 'publish',
 					'post_parent'      => $parent_act_id,
-					'orderby'          => 'menu_order',
-					'order'            => 'ASC',
+					'orderby'          => [
+						'menu_order' => 'ASC',
+						'date'       => 'DESC',
+						'title'      => 'ASC',
+					],
 					'suppress_filters' => false,
 					'numberposts'      => self::POSTS_LIMIT,
 				];
@@ -350,8 +353,10 @@ if ( ! class_exists( 'NewCovers_Controller' ) ) {
 
 			$query_args = [
 				'post_type'      => 'post',
-				'order'          => 'DESC',
-				'orderby'        => 'date',
+				'orderby'        => [
+					'date'       => 'DESC',
+					'title'      => 'ASC',
+				],
 				'no_found_rows'  => true,
 				'posts_per_page' => self::POSTS_LIMIT,
 			];

--- a/classes/controller/blocks/class-newcovers-controller.php
+++ b/classes/controller/blocks/class-newcovers-controller.php
@@ -354,8 +354,8 @@ if ( ! class_exists( 'NewCovers_Controller' ) ) {
 			$query_args = [
 				'post_type'      => 'post',
 				'orderby'        => [
-					'date'       => 'DESC',
-					'title'      => 'ASC',
+					'date'  => 'DESC',
+					'title' => 'ASC',
 				],
 				'no_found_rows'  => true,
 				'posts_per_page' => self::POSTS_LIMIT,


### PR DESCRIPTION
[JIRA issue #2910](https://jira.greenpeace.org/browse/PLANET-2910)

The updated sort order behaviour [reference.](https://planet4.greenpeace.org/handbook/block-covers/#behaviour-of-covers)

Note : The changes are made for both blocks (Old [Take action Covers] covers block and new Covers block )