### PR TITLE
PLANET-3008 Removed blocks: Take Action, Campaign Thumbnails and CFC blocks

### DIFF
--- a/classes/controller/blocks/class-campaignthumbnail-controller.php
+++ b/classes/controller/blocks/class-campaignthumbnail-controller.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'CampaignThumbnail_Controller' ) ) {
 				'label'         => __( 'Campaign Thumbnail', 'planet4-blocks-backend' ),
 				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/campaign_thumbnail.png' ) . '" />',
 				'attrs'         => $fields,
-				'post_type'     => P4BKS_ALLOWED_PAGETYPE,
+				'post_type'     => [''],
 			];
 
 			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );

--- a/classes/controller/blocks/class-contentfourcolumn-controller.php
+++ b/classes/controller/blocks/class-contentfourcolumn-controller.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'ContentFourColumn_Controller' ) ) {
 				'label'         => __( 'Content Four Column', 'planet4-blocks-backend' ),
 				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/content_four_column.png' ) . '" />',
 				'attrs'         => $fields,
-				'post_type'     => P4BKS_ALLOWED_PAGETYPE,
+				'post_type'     => [''],
 			];
 
 			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );

--- a/classes/controller/blocks/class-covers-controller.php
+++ b/classes/controller/blocks/class-covers-controller.php
@@ -103,7 +103,7 @@ if ( ! class_exists( 'Covers_Controller' ) ) {
 				 * See above, to where the the assignment to the $fields variable was made.
 				 */
 				'attrs'         => $fields,
-				'post_type'     => P4BKS_ALLOWED_PAGETYPE,
+				'post_type'     => [''],
 			];
 
 			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );


### PR DESCRIPTION
The Take Action, Campaign Thumbnails and CFC blocks are replaced by new covers block, hence we hide them on page 'Add page element' model pop up.

**Note:** On tag pages these blocks are still in use.