### PR TITLE
PLANET-3035 - Added alt_text to happy point block

### DIFF
--- a/classes/controller/blocks/class-happypoint-controller.php
+++ b/classes/controller/blocks/class-happypoint-controller.php
@@ -154,6 +154,7 @@ if ( ! class_exists( 'HappyPoint_Controller' ) ) {
 			$fields['engaging_network_id'] = $options['engaging_network_form_id'] ?? '';
 			$fields['opacity']             = $opacity;
 			$fields['default_image']       = get_bloginfo( 'template_directory' ) . '/images/happy-point-block-bg.jpg';
+			$fields['background_alt']      = get_post_meta( $fields['background'], '_wp_attachment_image_alt', true ) ?? 'Happy point background image';
 
 			$data = [
 				'fields' => $fields,

--- a/includes/blocks/happy_point.twig
+++ b/includes/blocks/happy_point.twig
@@ -7,6 +7,7 @@
 				     border="0"
 				     srcset="{{ fields.background_srcset }}"
 				     sizes="{{ fields.background_sizes }}"
+				     alt="{{ fields.background_alt }}"
 				/>
 			</picture>
 			<div class="container">


### PR DESCRIPTION
For accessibility reasons all images should have an alt_text attribute set.
This commit makes sure the happy point tries to fetch an alt_text from the media library and otherwise adds a default generic alt_text