### PR TITLE
PLANET-3227 remove old blocks

### DIFF
--- a/classes/controller/blocks/class-carousel-controller.php
+++ b/classes/controller/blocks/class-carousel-controller.php
@@ -100,7 +100,7 @@ if ( ! class_exists( 'Carousel_Controller' ) ) {
 				'label'         => __( 'Carousel', 'planet4-blocks-backend' ),
 				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/take_action_carousel.png' ) . '" />',
 				'attrs'         => $fields,
-				'post_type'     => P4BKS_ALLOWED_PAGETYPE,
+				'post_type'     => [ 'do_not_show_replaced_by_gallery' ],
 			];
 
 			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );

--- a/classes/controller/blocks/class-contentthreecolumn-controller.php
+++ b/classes/controller/blocks/class-contentthreecolumn-controller.php
@@ -77,7 +77,7 @@ if ( ! class_exists( 'ContentThreeColumn_Controller' ) ) {
 				'label'         => __( 'Three Columns', 'planet4-blocks-backend' ),
 				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/three_columns.png' ) . '" />',
 				'attrs'         => $fields,
-				'post_type'     => P4BKS_ALLOWED_PAGETYPE,
+				'post_type'     => [ 'do_not_show_replaced_by_gallery' ],
 			];
 
 			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );

--- a/classes/controller/blocks/class-staticfourcolumn-controller.php
+++ b/classes/controller/blocks/class-staticfourcolumn-controller.php
@@ -104,7 +104,7 @@ if ( ! class_exists( 'StaticFourColumn_Controller' ) ) {
 				'label'         => __( 'Static Four Column', 'planet4-blocks-backend' ),
 				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/static_four_column.png' ) . '" />',
 				'attrs'         => $fields,
-				'post_type'     => P4BKS_ALLOWED_PAGETYPE,
+				'post_type'     => [ 'do_not_show_replaced_by_columns' ],
 			];
 
 			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );

--- a/classes/controller/blocks/class-tasks-controller.php
+++ b/classes/controller/blocks/class-tasks-controller.php
@@ -132,7 +132,7 @@ if ( ! class_exists( 'Tasks_Controller' ) ) {
 				'label'         => __( 'Take action tasks', 'planet4-blocks-backend' ),
 				'listItemImage' => '<img src="' . esc_url( plugins_url() . '/planet4-plugin-blocks/admin/images/take_action_tasks.png' ) . '" />',
 				'attrs'         => $fields,
-				'post_type'     => P4BKS_ALLOWED_PAGETYPE,
+				'post_type'     => [ 'do_not_show_replaced_by_columns' ],
 			];
 
 			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );

--- a/classes/controller/blocks/class-twocolumn-controller.php
+++ b/classes/controller/blocks/class-twocolumn-controller.php
@@ -140,7 +140,7 @@ if ( ! class_exists( 'TwoColumn_Controller' ) ) {
 				 * See above, to where the the assignment to the $fields variable was made.
 				 */
 				'attrs'         => $fields,
-				'post_type'     => P4BKS_ALLOWED_PAGETYPE,
+				'post_type'     => [ 'do_not_show_replaced_by_columns' ],
 			];
 
 			shortcode_ui_register_for_shortcode( 'shortcake_' . self::BLOCK_NAME, $shortcode_ui_args );


### PR DESCRIPTION
[Related Jira Issue](https://jira.greenpeace.org/browse/PLANET-3227)

Making the 5 blocks that we have replaced not available in the interface, while leaving them working (for any pages that still have them).

This is temporary, until the NROs replace their existing blocks with the new ones, in which time we will completely remove these 5 from our codebase
