### PR TITLE
PLANET-3218: Double vertical spacing

### DIFF
--- a/assets/scss/components/_articles.scss
+++ b/assets/scss/components/_articles.scss
@@ -1,6 +1,5 @@
 .article-listing-intro {
   display: flex;
-  margin-top: $n60;
 
   & > div:first-of-type {
     padding-left: 0;


### PR DESCRIPTION
This reverts a change made to the articles block to add some padding to the top which caused the present bug. The padding should be added only for the explore page, not for *every* articles block. 

So this fixes the "Double vertical spacing" issue, but "unfixes" the previous one (3158, add spacing in the explore page), which should probably be reopened.

Ref: https://jira.greenpeace.org/browse/PLANET-3218

