### PR TITLE
PLANET-3372 Added report for different carousel header styles

### DIFF
--- a/planet4-blocks.php
+++ b/planet4-blocks.php
@@ -167,7 +167,7 @@ function plugin_blocks_report() {
 	// phpcs:disable
 	foreach ( $blocks as $block ) {
 		$block = substr( $block, 10 );
-		$shortcode = '%[shortcake_' . $wpdb->esc_like( $block ) . '%';
+		$shortcode = '%[shortcake_' . $wpdb->esc_like( $block ) . ' %';
 		$sql       = $wpdb->prepare(
 			"SELECT ID, post_title
 			FROM `wp_posts` 
@@ -191,6 +191,39 @@ function plugin_blocks_report() {
 			echo '<br>';
 		}
 	}
+
+	// Add to the report a breakdown of different styles for carousel Header
+	$sql       = "SELECT ID, post_title
+						FROM ". $wpdb->prefix . "posts 
+						WHERE post_status = 'publish'
+				      	AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic'";
+	$results = $wpdb->get_results( $sql );
+	echo '<hr>';
+	echo '<h2>Carousel Header Full Width Classic style</h2>';
+	foreach ( $results as $result ) {
+		echo '<a href="post.php?post=' . $result->ID . '&action=edit" >' . $result->post_title . '</a>';
+		echo '<br>';
+	}
+
+	// Add to the report a breakdown of different styles for carousel Header
+	// Given that the default (if no style is defined) is the Slide to Gray, include in the query
+	// everything that is not Full Width Classic.
+	$sql       = "SELECT ID, post_title
+						FROM ". $wpdb->prefix . "posts 
+						WHERE post_status = 'publish'
+				      	AND `post_content` REGEXP 'shortcake_carousel_header'
+						AND ID NOT IN (SELECT ID
+											FROM ". $wpdb->prefix . "posts 
+											WHERE post_status = 'publish'
+											AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic')";
+	$results = $wpdb->get_results( $sql );
+	echo '<hr>';
+	echo '<h2>Carousel Header Zoom and Slide to Grey</h2>';
+	foreach ( $results as $result ) {
+		echo '<a href="post.php?post=' . $result->ID . '&action=edit" >' . $result->post_title . '</a>';
+		echo '<br>';
+	}
+
 	// phpcs:enable
 }
 
@@ -213,18 +246,36 @@ function plugin_blocks_report_json() {
 		foreach ( $blocks as $block ) {
 
 			$block     = substr( $block, 10 );
-			$shortcode = '%[shortcake_' . $wpdb->esc_like( $block ) . '%';
+			$shortcode = '%[shortcake_' . $wpdb->esc_like( $block ) . ' %';
 			$sql       = $wpdb->prepare(
 				"SELECT count(ID) AS cnt
 				FROM `wp_posts` 
 				WHERE post_status = 'publish' 
 				AND `post_content` LIKE %s", $shortcode );
-
 			$results = $wpdb->get_var( $sql );
 
 			$report[ ucfirst( str_replace( '_', ' ', $block ) ) ] = $results;
 
 		}
+
+		// Add to the report a breakdown of different styles for carousel Header
+		$sql       = "SELECT count(ID) AS cnt
+						FROM ". $wpdb->prefix . "posts 
+						WHERE post_status = 'publish'
+				      	AND `post_content` REGEXP 'shortcake_carousel_header'
+						AND ID NOT IN (SELECT ID
+											FROM ". $wpdb->prefix . "posts 
+											WHERE post_status = 'publish'
+											AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic')";
+		$cnt = $wpdb->get_var( $sql );
+		$report['CarouselHeader-Zoom-And-Slide'] = $cnt;
+		$sql       = "SELECT count(ID) AS cnt
+						FROM ". $wpdb->prefix . "posts 
+						WHERE post_status = 'publish'
+				      	AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic'";
+		$cnt = $wpdb->get_var( $sql );
+		$report['CarouselHeader-Full-Width-Classic'] = $cnt;
+
 		wp_cache_add( $cache_key, $report, '', 3600 );
 
 	}


### PR DESCRIPTION
[Jira issue 3372](https://jira.greenpeace.org/browse/PLANET-3346)

This adds two rows to the plugins usage report about which style of the carousel Header block is used
In the admin pages of wordpress:
![plugins-report-admin](https://user-images.githubusercontent.com/2528229/55230855-b5dff180-5229-11e9-8d1f-dc47cd71cb08.png)
And in the json for the automatic report
![plugins-report](https://user-images.githubusercontent.com/2528229/55230817-98ab2300-5229-11e9-8ded-eb65fda7ec97.png)

Additionally it fixes a bug that existed that was making the "Carousel" to also report all  "Carousel_header" blocks. 

