### PR TITLE
Bug/planet 3376 publications link are empty

### DIFF
--- a/classes/controller/blocks/class-newcovers-controller.php
+++ b/classes/controller/blocks/class-newcovers-controller.php
@@ -514,6 +514,7 @@ if ( ! class_exists( 'NewCovers_Controller' ) ) {
 					}
 
 					$post->permalink = get_permalink( $post );
+					$post->link      = get_permalink( $post );
 					$posts_array[]   = $post;
 				}
 			}


### PR DESCRIPTION
The publications were not including the link of the target because it was being assigned to the param permalink.
I have not removed the param permalink, because I didn't know if it was being used in some other context, and I have not changed the twig template to use permalink because it would stop being backwords compatible with the old four-columns block, but I have added the param link that the template is looking for.