### PR TITLE
Carousel Header: Truncate 32 chars instead of 30 in twig (no JIRA issue)

### DIFF
--- a/includes/blocks/carousel_header_full-width-classic.twig
+++ b/includes/blocks/carousel_header_full-width-classic.twig
@@ -36,7 +36,7 @@
 												<div class="container main-header">
 													<div class="carousel-captions-wrapper">
 														{% if ( attribute( fields, 'header_' ~ i ) ) %}
-															<h1>{{ carouselTools.truncateChars( attribute( fields, 'header_' ~ i ), 30 ) }}</h1>
+															<h1>{{ carouselTools.truncateChars( attribute( fields, 'header_' ~ i ), 32 ) }}</h1>
 														{% endif %}
 														{% if ( attribute( fields, 'description_' ~ i )  ) %}
 														 	<p>{{ carouselTools.truncateChars( attribute( fields, 'description_' ~ i ), 200 ) }}</p>


### PR DESCRIPTION
Reported via Rocket Chat, no JIRA issue.