### PR TITLE
Testing in PHP 7.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,7 @@ workflows:
   main:
     jobs:
       - php70-build
-      - php71-build
-      - php72-build
+      - php73-build
       - build-and-test-codeception:
           context: org-global
           filters:
@@ -67,25 +66,19 @@ jobs:
   php70-build:
     <<: *php_job
     docker:
-      - image: gcr.io/planet-4-151612/p4-unit-tests:php7.0
+      - image: gcr.io/planet-4-151612/p4-unit-tests:php7.0-develop
       - image: *mysql_image
 
-  php71-build:
+  php73-build:
     <<: *php_job
     docker:
-      - image: gcr.io/planet-4-151612/p4-unit-tests:php7.1
-      - image: *mysql_image
-
-  php72-build:
-    <<: *php_job
-    docker:
-      - image: gcr.io/planet-4-151612/p4-unit-tests:php7.2
+      - image: gcr.io/planet-4-151612/p4-unit-tests:php7.3-develop
       - image: *mysql_image
 
   build-and-test-codeception:
     docker:
       - image: gcr.io/planet-4-151612/p4-builder:latest
-    working_directory:  /home/circleci/
+    working_directory: /home/circleci/
     environment:
       APP_HOSTNAME: www.planet4.test
       APP_HOSTPATH:


### PR DESCRIPTION
As planet4-docker now builds with PHP7.3, this adds PHP v7.3 test environment and removes 7.1 and 7.2

Will be ready to merge when:

1. redis connection issue in codeception tests is identified
2. https://github.com/greenpeace/planet4-circleci-unit-tests/pull/2 is merged