### PR TITLE
PLANET-3380 admin convert blocks

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'Loader' ) ) {
 		 *
 		 * @return Loader
 		 */
-		public static function get_instance( $services = array(), $view_class ) : Loader {
+		public static function get_instance( $services, $view_class ) : Loader {
 			if ( ! isset( self::$instance ) ) {
 				self::$instance = new self( $services, $view_class );
 			}
@@ -56,7 +56,7 @@ if ( ! class_exists( 'Loader' ) ) {
 		 * @param array  $services The Controller services to inject.
 		 * @param string $view_class The View class name.
 		 */
-		private function __construct( $services = array(), $view_class ) {
+		private function __construct( $services, $view_class ) {
 			$this->load_services( $services, $view_class );
 			$this->check_requirements();
 			add_action( 'plugins_loaded', [ $this, 'load_i18n' ] );

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -32,7 +32,6 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 					[ $this, 'plugin_blocks_report' ]
 				);
 			}
-			add_action( 'rest_api_init', [ $this, 'plugin_blocks_report_register_rest_route' ] );
 		}
 
 		/**
@@ -58,7 +57,7 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 
 			// phpcs:disable
 			foreach ( $blocks as $block ) {
-				$block = substr( $block, 10 );
+				$block     = substr( $block, 10 );
 				$shortcode = '%[shortcake_' . $wpdb->esc_like( $block ) . ' %';
 				$sql       = $wpdb->prepare(
 					"SELECT ID, post_title
@@ -86,9 +85,9 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 
 			// Add to the report a breakdown of different styles for carousel Header
 			$sql     = "SELECT ID, post_title
-						FROM ". $wpdb->prefix . "posts 
-						WHERE post_status = 'publish'
-				      	AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic'";
+                        FROM ". $wpdb->prefix . "posts 
+                        WHERE post_status = 'publish'
+                        AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic'";
 			$results = $wpdb->get_results( $sql );
 			echo '<hr>';
 			echo '<h2>Carousel Header Full Width Classic style</h2>';
@@ -101,13 +100,13 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 			// Given that the default (if no style is defined) is the Slide to Gray, include in the query
 			// everything that is not Full Width Classic.
 			$sql     = "SELECT ID, post_title
-						FROM ". $wpdb->prefix . "posts 
-						WHERE post_status = 'publish'
-				      	AND `post_content` REGEXP 'shortcake_carousel_header'
-						AND ID NOT IN (SELECT ID
-											FROM ". $wpdb->prefix . "posts 
-											WHERE post_status = 'publish'
-											AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic')";
+                        FROM ". $wpdb->prefix . "posts 
+                        WHERE post_status = 'publish'
+                        AND `post_content` REGEXP 'shortcake_carousel_header'
+                        AND ID NOT IN (SELECT ID
+                            FROM ". $wpdb->prefix . "posts 
+                            WHERE post_status = 'publish'
+                            AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic')";
 			$results = $wpdb->get_results( $sql );
 			echo '<hr>';
 			echo '<h2>Carousel Header Zoom and Slide to Grey</h2>';
@@ -117,78 +116,6 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 			}
 
 			// phpcs:enable
-		}
-
-		/**
-		 * Finds blocks usage in pages/posts.
-		 */
-		public function plugin_blocks_report_json() {
-			global $wpdb, $shortcode_tags;
-
-			$cache_key = 'plugin-blocks-report';
-			$report    = wp_cache_get( $cache_key );
-
-			if ( ! $report ) {
-				// Array filtering on shortcake shortcodes.
-				$blocks = array_filter( array_keys( $shortcode_tags ), 'is_shortcake' );
-
-				$report = [];
-
-				// phpcs:disable
-				foreach ( $blocks as $block ) {
-
-					$block     = substr( $block, 10 );
-					$shortcode = '%[shortcake_' . $wpdb->esc_like( $block ) . ' %';
-					$sql       = $wpdb->prepare(
-						"SELECT count(ID) AS cnt
-				FROM `wp_posts` 
-				WHERE post_status = 'publish' 
-				AND `post_content` LIKE %s", $shortcode );
-					$results = $wpdb->get_var( $sql );
-
-					$report[ ucfirst( str_replace( '_', ' ', $block ) ) ] = $results;
-
-				}
-
-				// Add to the report a breakdown of different styles for carousel Header
-				$sql = "SELECT count(ID) AS cnt
-						FROM ". $wpdb->prefix . "posts 
-						WHERE post_status = 'publish'
-				      	AND `post_content` REGEXP 'shortcake_carousel_header'
-						AND ID NOT IN (SELECT ID
-											FROM ". $wpdb->prefix . "posts 
-											WHERE post_status = 'publish'
-											AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic')";
-				$cnt = $wpdb->get_var( $sql );
-				$report['CarouselHeader-Zoom-And-Slide'] = $cnt;
-				$sql = "SELECT count(ID) AS cnt
-						FROM ". $wpdb->prefix . "posts 
-						WHERE post_status = 'publish'
-				      	AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic'";
-				$cnt = $wpdb->get_var( $sql );
-				$report['CarouselHeader-Full-Width-Classic'] = $cnt;
-
-				wp_cache_add( $cache_key, $report, '', 3600 );
-
-			}
-			return $report;
-
-			// phpcs:enable
-		}
-
-
-		/**
-		 * Register API route for report of blocks usage in pages/posts.
-		 */
-		public function plugin_blocks_report_register_rest_route() {
-			register_rest_route(
-				'plugin_blocks/v1',
-				'/plugin_blocks_report/',
-				[
-					'methods'  => 'GET',
-					'callback' => [ $this, 'plugin_blocks_report_json' ],
-				]
-			);
 		}
 
 		/**

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -1,0 +1,221 @@
+<?php
+/**
+* Blocks Usage class
+*
+* @package P4BKS\Controllers\Menu
+* @since 1.40.0
+*/
+
+namespace P4BKS\Controllers\Menu;
+
+if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
+
+	/**
+	 * Class Blocks_Usage_Controller
+	 */
+	class Blocks_Usage_Controller extends Controller {
+
+		/**
+		 * Create menu/submenu entry.
+		 */
+		public function create_admin_menu() {
+
+			$current_user = wp_get_current_user();
+
+			if ( in_array( 'administrator', $current_user->roles, true ) && current_user_can( 'manage_options' ) ) {
+				add_submenu_page(
+					P4BKS_PLUGIN_SLUG_NAME,
+					__( 'Usage', 'planet4-blocks-backend' ),
+					__( 'Usage', 'planet4-blocks-backend' ),
+					'manage_options',
+					'plugin_blocks_report',
+					[ $this, 'plugin_blocks_report' ]
+				);
+			}
+			add_action( 'rest_api_init', [ $this, 'plugin_blocks_report_register_rest_route' ] );
+		}
+
+		/**
+		 * Filters array elements on being a shortcake shortcode
+		 *
+		 * @param string $shortcode The shortcode.
+		 * @return bool
+		 */
+		public function is_shortcake( $shortcode ) {
+			$found = strpos( $shortcode, 'shortcake' );
+			if ( false !== $found ) {
+				return true;
+			}
+		}
+
+		/**
+		 * Finds blocks usage in pages/posts.
+		 */
+		public function plugin_blocks_report() {
+			global $wpdb, $shortcode_tags;
+
+			// Array filtering on shortcake shortcodes.
+			$blocks = array_filter( array_keys( $shortcode_tags ), [ $this, 'is_shortcake' ] );
+			sort( $blocks );
+
+			// phpcs:disable
+			foreach ( $blocks as $block ) {
+				$block = substr( $block, 10 );
+				$shortcode = '%[shortcake_' . $wpdb->esc_like( $block ) . ' %';
+				$sql       = $wpdb->prepare(
+					"SELECT ID, post_title
+					FROM `wp_posts` 
+					WHERE post_status = 'publish' 
+					AND `post_content` LIKE %s
+					ORDER BY post_title",
+					$shortcode );
+
+				$results = $wpdb->get_results( $sql );
+
+				// Confusion between old and new covers.
+				if ( 'covers' === $block ) {
+					$block = 'Take Action Covers - Old block';
+				}
+
+				echo '<hr>';
+				echo '<h2>' . ucfirst( str_replace( '_', ' ', $block ) ) . '</h2>';
+
+				foreach ( $results as $result ) {
+					echo '<a href="post.php?post=' . $result->ID . '&action=edit" >' . $result->post_title . '</a>';
+					echo '<br>';
+				}
+			}
+
+			// Add to the report a breakdown of different styles for carousel Header
+			$sql     = "SELECT ID, post_title
+						FROM ". $wpdb->prefix . "posts 
+						WHERE post_status = 'publish'
+				      	AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic'";
+			$results = $wpdb->get_results( $sql );
+			echo '<hr>';
+			echo '<h2>Carousel Header Full Width Classic style</h2>';
+			foreach ( $results as $result ) {
+				echo '<a href="post.php?post=' . $result->ID . '&action=edit" >' . $result->post_title . '</a>';
+				echo '<br>';
+			}
+
+			// Add to the report a breakdown of different styles for carousel Header
+			// Given that the default (if no style is defined) is the Slide to Gray, include in the query
+			// everything that is not Full Width Classic.
+			$sql     = "SELECT ID, post_title
+						FROM ". $wpdb->prefix . "posts 
+						WHERE post_status = 'publish'
+				      	AND `post_content` REGEXP 'shortcake_carousel_header'
+						AND ID NOT IN (SELECT ID
+											FROM ". $wpdb->prefix . "posts 
+											WHERE post_status = 'publish'
+											AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic')";
+			$results = $wpdb->get_results( $sql );
+			echo '<hr>';
+			echo '<h2>Carousel Header Zoom and Slide to Grey</h2>';
+			foreach ( $results as $result ) {
+				echo '<a href="post.php?post=' . $result->ID . '&action=edit" >' . $result->post_title . '</a>';
+				echo '<br>';
+			}
+
+			// phpcs:enable
+		}
+
+		/**
+		 * Finds blocks usage in pages/posts.
+		 */
+		public function plugin_blocks_report_json() {
+			global $wpdb, $shortcode_tags;
+
+			$cache_key = 'plugin-blocks-report';
+			$report    = wp_cache_get( $cache_key );
+
+			if ( ! $report ) {
+				// Array filtering on shortcake shortcodes.
+				$blocks = array_filter( array_keys( $shortcode_tags ), 'is_shortcake' );
+
+				$report = [];
+
+				// phpcs:disable
+				foreach ( $blocks as $block ) {
+
+					$block     = substr( $block, 10 );
+					$shortcode = '%[shortcake_' . $wpdb->esc_like( $block ) . ' %';
+					$sql       = $wpdb->prepare(
+						"SELECT count(ID) AS cnt
+				FROM `wp_posts` 
+				WHERE post_status = 'publish' 
+				AND `post_content` LIKE %s", $shortcode );
+					$results = $wpdb->get_var( $sql );
+
+					$report[ ucfirst( str_replace( '_', ' ', $block ) ) ] = $results;
+
+				}
+
+				// Add to the report a breakdown of different styles for carousel Header
+				$sql = "SELECT count(ID) AS cnt
+						FROM ". $wpdb->prefix . "posts 
+						WHERE post_status = 'publish'
+				      	AND `post_content` REGEXP 'shortcake_carousel_header'
+						AND ID NOT IN (SELECT ID
+											FROM ". $wpdb->prefix . "posts 
+											WHERE post_status = 'publish'
+											AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic')";
+				$cnt = $wpdb->get_var( $sql );
+				$report['CarouselHeader-Zoom-And-Slide'] = $cnt;
+				$sql = "SELECT count(ID) AS cnt
+						FROM ". $wpdb->prefix . "posts 
+						WHERE post_status = 'publish'
+				      	AND `post_content` REGEXP 'shortcake_carousel_header.*full-width-classic'";
+				$cnt = $wpdb->get_var( $sql );
+				$report['CarouselHeader-Full-Width-Classic'] = $cnt;
+
+				wp_cache_add( $cache_key, $report, '', 3600 );
+
+			}
+			return $report;
+
+			// phpcs:enable
+		}
+
+
+		/**
+		 * Register API route for report of blocks usage in pages/posts.
+		 */
+		public function plugin_blocks_report_register_rest_route() {
+			register_rest_route(
+				'plugin_blocks/v1',
+				'/plugin_blocks_report/',
+				[
+					'methods'  => 'GET',
+					'callback' => [ $this, 'plugin_blocks_report_json' ],
+				]
+			);
+		}
+
+		/**
+		 * Validates the settings input.
+		 *
+		 * @param array $settings The associative array with the settings that are registered for the plugin.
+		 *
+		 * @return bool
+		 */
+		public function validate( $settings ) : bool {
+			$has_errors = false;
+			return ! $has_errors;
+		}
+
+		/**
+		 * Sanitizes the settings input.
+		 *
+		 * @param array $settings The associative array with the settings that are registered for the plugin.
+		 */
+		public function sanitize( &$settings ) {
+			if ( $settings ) {
+				foreach ( $settings as $name => $setting ) {
+					$settings[ $name ] = sanitize_text_field( $setting );
+				}
+			}
+		}
+	}
+}

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -1,10 +1,10 @@
 <?php
 /**
-* Blocks Usage class
-*
-* @package P4BKS\Controllers\Menu
-* @since 1.40.0
-*/
+ * Blocks Usage class
+ *
+ * @package P4BKS\Controllers\Menu
+ * @since 1.40.0
+ */
 
 namespace P4BKS\Controllers\Menu;
 
@@ -41,11 +41,9 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 		 * @param string $shortcode The shortcode.
 		 * @return bool
 		 */
-		public function is_shortcake( $shortcode ) {
+		public function is_shortcake( $shortcode ) : bool {
 			$found = strpos( $shortcode, 'shortcake' );
-			if ( false !== $found ) {
-				return true;
-			}
+			return false !== $found ? true : false;
 		}
 
 		/**

--- a/classes/controller/menu/class-settings-controller.php
+++ b/classes/controller/menu/class-settings-controller.php
@@ -40,8 +40,8 @@ if ( ! class_exists( 'Settings_Controller' ) ) {
 		 * Render the settings page of the plugin.
 		 */
 		public function prepare_settings() {
-			$data = [];
-			$validated = $this->handle_submit($data );
+			$data      = [];
+			$validated = $this->handle_submit( $data );
 			if ( $validated ) {
 				$this->view->settings( $data );
 			}
@@ -50,7 +50,6 @@ if ( ! class_exists( 'Settings_Controller' ) ) {
 		/**
 		 * Handle form submit.
 		 *
-		 * @param mixed[] $current_user The current user.
 		 * @param mixed[] $data The form data.
 		 *
 		 * @return bool Array if validation is ok, false if validation fails.
@@ -58,7 +57,7 @@ if ( ! class_exists( 'Settings_Controller' ) ) {
 		public function handle_submit( &$data ) : bool {
 			// CSRF protection.
 			$nonce   = filter_input( INPUT_POST, '_wpnonce', FILTER_SANITIZE_STRING );
-			$post_id = filter_input( INPUT_POST, 'p4bks_post_id', FILTER_SANITIZE_NUMBER_INT );
+			$page_id = filter_input( INPUT_POST, 'p4bks_page_id', FILTER_SANITIZE_NUMBER_INT );
 
 			$data['nonce_action'] = 'convert-blocks-nonce';
 			$data['form_submit']  = 0;
@@ -70,38 +69,43 @@ if ( ! class_exists( 'Settings_Controller' ) ) {
 					$data['message'] = __( 'Nonce verification failed!', 'planet4-blocks-backend' );
 					return false;
 				} else {
-					$data['message'] = $this->replace_shortcodes( [ $post_id ] );
+					$data['message'] = $this->replace_shortcodes( [ $page_id ] );
 				}
 			}
 			return true;
 		}
 
 		/**
-		 * @param array $args
+		 * Replace shortcodes in one or more Pages.
+		 *
+		 * @param array $page_ids Array with the ids of the pages that need shortcode replacements.
 		 *
 		 * @return string
 		 */
-		public function replace_shortcodes( $args = [] ) : string {
+		public function replace_shortcodes( $page_ids = [] ) : string {
 
-			// Supply a post ID as first argument to update a single, specific post.
-			$post_id = $args[0] ?? null;
+			// Supply a page ID as first argument to update a single, specific page.
+			$page_id = $page_ids[0] ?? null;
 
 			try {
 				$replacer = new ShortcodeReplacer();
 				try {
-					$updated = $replacer->replace_all( $post_id );
+					$updated = $replacer->replace_all( $page_id );
 				} catch ( \Exception $e ) {
 					return __( 'Exception: ', 'planet4-blocks-backend' ) . $e->getMessage();
 				}
 
-				if ( $post_id ) {
+				if ( $page_id ) {
 					if ( $updated ) {
-						return sprintf( __( 'Replaced shortcodes in post %d', 'planet4-blocks-backend' ), $post_id );
+						// translators: %d = The page ID.
+						return sprintf( __( 'Replaced shortcodes in page %d', 'planet4-blocks-backend' ), $page_id );
 					} else {
-						return sprintf( __( 'No shortcodes replaced in post %d', 'planet4-blocks-backend' ), $post_id );
+						// translators: %d = The page ID.
+						return sprintf( __( 'No shortcodes replaced in page %d', 'planet4-blocks-backend' ), $page_id );
 					}
 				} else {
-					return sprintf( __( 'Replaced shortcodes in %d posts ', 'planet4-blocks-backend' ), $updated );
+					// translators: %d = Number of pages that shortcode replacement took place in.
+					return sprintf( __( 'Replaced shortcodes in %d pages ', 'planet4-blocks-backend' ), $updated );
 				}
 			} catch ( \Error $e ) {
 				return $e->getMessage();

--- a/classes/controller/menu/class-settings-controller.php
+++ b/classes/controller/menu/class-settings-controller.php
@@ -40,11 +40,9 @@ if ( ! class_exists( 'Settings_Controller' ) ) {
 		 * Render the settings page of the plugin.
 		 */
 		public function prepare_settings() {
-			$data      = [];
-			$validated = $this->handle_submit( $data );
-			if ( $validated ) {
-				$this->view->settings( $data );
-			}
+			$data = [];
+			$this->handle_submit( $data );
+			$this->view->settings( $data );
 		}
 
 		/**

--- a/includes/settings.twig
+++ b/includes/settings.twig
@@ -7,7 +7,7 @@
     <form id="p4bks_main_settings_form" name="p4bks_main_settings_form" method="post">
         {{ fn( 'wp_nonce_field', nonce_action, '_wpnonce', true, false )|raw }}
         <p class="submit">
-            <input type="text" name="p4bks_post_id" id="p4bks_post_id" value="" placeholder="{{ __( 'Post ID', 'planet4-blocks-backend' ) }}">
+            <input type="text" name="p4bks_page_id" id="p4bks_page_id" value="" placeholder="{{ __( 'Post ID', 'planet4-blocks-backend' ) }}">
             <input type="submit" name="p4bks_convert_blocks_button" id="p4bks_convert_blocks_button" class="button button-primary" value="{{ __( 'Convert block(s)', 'planet4-blocks-backend' ) }}">&nbsp;
             <span class="convert-blocks-response cp-success">{{ message }}</span>
             <br />{{ __( '1) The blocks "Static four column", "Two columns" and "Take action cards" will be replaced by block "Columns"', 'planet4-blocks-backend' ) }}

--- a/includes/settings.twig
+++ b/includes/settings.twig
@@ -7,7 +7,7 @@
     <form id="p4bks_main_settings_form" name="p4bks_main_settings_form" method="post">
         {{ fn( 'wp_nonce_field', nonce_action, '_wpnonce', true, false )|raw }}
         <p class="submit">
-            <input type="text" name="p4bks_page_id" id="p4bks_page_id" value="" placeholder="{{ __( 'Post ID', 'planet4-blocks-backend' ) }}">
+            <input type="text" name="p4bks_page_id" id="p4bks_page_id" value="" placeholder="{{ __( 'Page ID', 'planet4-blocks-backend' ) }}">
             <input type="submit" name="p4bks_convert_blocks_button" id="p4bks_convert_blocks_button" class="button button-primary" value="{{ __( 'Convert block(s)', 'planet4-blocks-backend' ) }}">&nbsp;
             <span class="convert-blocks-response cp-success">{{ message }}</span>
             <br />{{ __( '1) The blocks "Static four column", "Two columns" and "Take action cards" will be replaced by block "Columns"', 'planet4-blocks-backend' ) }}

--- a/includes/settings.twig
+++ b/includes/settings.twig
@@ -4,32 +4,15 @@
         <h2>{{ __( 'Settings', 'planet4-blocks-backend' ) }}</h2>
     </div>
 
-    {{ fn( 'settings_errors' ) }}
-
-    <form id="p4bks_main_settings_form" name="p4bks_main_settings_form" method="post" action="options.php"> {# ../../../../wp-admin/options.php #}
-
-        {{ fn( 'settings_fields', 'p4bks_main_settings_group' ) }}
-        {{ fn( 'do_settings_sections', 'p4bks_main_settings_group' ) }}
-
-        <br /><br />
-        <table class="form-table">
-            <tr valign="top">
-                <th>{{ __( 'Language', 'planet4-blocks-backend' ) }}:</th>
-                <td>
-                    <select id="p4bks_lang" name="p4bks_main_settings[p4bks_lang]">
-                        <option selected disabled>- {{ __( 'Select Language', 'planet4-blocks-backend' ) }} -</option>
-                        {% for key, language in available_languages %}
-                            {% if key == settings.p4bks_lang %}
-                                <option value="{{ key }}" selected>{{ language }}</option>
-                            {% else %}
-                                <option value="{{ key }}">{{ language }}</option>
-                            {% endif %}
-                        {% endfor %}
-                    </select>
-                </td>
-            </tr>
-        </table>
-        {{ fn( 'submit_button', __( 'Save Changes', 'planet4-blocks-backend' ), 'primary', 'p4bks_main_settings_save_button' ) }}
+    <form id="p4bks_main_settings_form" name="p4bks_main_settings_form" method="post">
+        {{ fn( 'wp_nonce_field', nonce_action, '_wpnonce', true, false )|raw }}
+        <p class="submit">
+            <input type="text" name="p4bks_post_id" id="p4bks_post_id" value="" placeholder="{{ __( 'Post ID', 'planet4-blocks-backend' ) }}">
+            <input type="submit" name="p4bks_convert_blocks_button" id="p4bks_convert_blocks_button" class="button button-primary" value="{{ __( 'Convert block(s)', 'planet4-blocks-backend' ) }}">&nbsp;
+            <span class="convert-blocks-response cp-success">{{ message }}</span>
+            <br />{{ __( '1) The blocks "Static four column", "Two columns" and "Take action cards" will be replaced by block "Columns"', 'planet4-blocks-backend' ) }}
+            <br />{{ __( '2) The blocks "Three columns" and "Carousel" will be replaced by block "Gallery"', 'planet4-blocks-backend' ) }}
+        </p>
     </form>
     <div class="clear"></div>
 

--- a/planet4-blocks.php
+++ b/planet4-blocks.php
@@ -140,7 +140,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				try {
 					WP_CLI::log( 'Replacing shortcodes...' );
 
-
 					$updater = new P4BKS\Command\ShortcodeReplacer();
 					$updated = $updater->replace_all( $post_id );
 
@@ -161,6 +160,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			}
 		);
 	} catch ( \Exception $e ) {
-		WP_CLI::error( 'Exception: ' . $e->getMessage() );
+		WP_CLI::log( 'Exception: ' . $e->getMessage() );
 	}
 }

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -279,7 +279,7 @@ class ClassLoader
      */
     public function setApcuPrefix($apcuPrefix)
     {
-        $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
+        $this->apcuPrefix = function_exists('apcu_fetch') && ini_get('apc.enabled') ? $apcuPrefix : null;
     }
 
     /**
@@ -377,7 +377,7 @@ class ClassLoader
             $subPath = $class;
             while (false !== $lastPos = strrpos($subPath, '\\')) {
                 $subPath = substr($subPath, 0, $lastPos);
-                $search = $subPath . '\\';
+                $search = $subPath.'\\';
                 if (isset($this->prefixDirsPsr4[$search])) {
                     $pathEnd = DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $lastPos + 1);
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -32,6 +32,7 @@ return array(
     'P4BKS\\Controllers\\Blocks\\Tasks_Controller' => $baseDir . '/classes/controller/blocks/class-tasks-controller.php',
     'P4BKS\\Controllers\\Blocks\\Timeline_Controller' => $baseDir . '/classes/controller/blocks/class-timeline-controller.php',
     'P4BKS\\Controllers\\Blocks\\TwoColumn_Controller' => $baseDir . '/classes/controller/blocks/class-twocolumn-controller.php',
+    'P4BKS\\Controllers\\Menu\\Blocks_Usage_Controller' => $baseDir . '/classes/controller/menu/class-blocks-usage-controller.php',
     'P4BKS\\Controllers\\Menu\\Controller' => $baseDir . '/classes/controller/menu/class-controller.php',
     'P4BKS\\Controllers\\Menu\\Settings_Controller' => $baseDir . '/classes/controller/menu/class-settings-controller.php',
     'P4BKS\\Controllers\\Uninstall_Controller' => $baseDir . '/classes/controller/class-uninstall-controller.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -62,6 +62,7 @@ class ComposerStaticInit356100170ff2882375cd04c4c76f9df3
         'P4BKS\\Controllers\\Blocks\\Tasks_Controller' => __DIR__ . '/../..' . '/classes/controller/blocks/class-tasks-controller.php',
         'P4BKS\\Controllers\\Blocks\\Timeline_Controller' => __DIR__ . '/../..' . '/classes/controller/blocks/class-timeline-controller.php',
         'P4BKS\\Controllers\\Blocks\\TwoColumn_Controller' => __DIR__ . '/../..' . '/classes/controller/blocks/class-twocolumn-controller.php',
+        'P4BKS\\Controllers\\Menu\\Blocks_Usage_Controller' => __DIR__ . '/../..' . '/classes/controller/menu/class-blocks-usage-controller.php',
         'P4BKS\\Controllers\\Menu\\Controller' => __DIR__ . '/../..' . '/classes/controller/menu/class-controller.php',
         'P4BKS\\Controllers\\Menu\\Settings_Controller' => __DIR__ . '/../..' . '/classes/controller/menu/class-settings-controller.php',
         'P4BKS\\Controllers\\Uninstall_Controller' => __DIR__ . '/../..' . '/classes/controller/class-uninstall-controller.php',


### PR DESCRIPTION
Add Menu Item for Blocks and a submenu item. The Blocks Usage logic was moved to the submenu item and in the main menu item we added a button and an input for Editors to use for replacing block shortcodes with new ones.

*`class-blocks-usage-controller.php` has the code that was in plugin-blocks.php (related to block usage report functionality)... so no real changes on this one, only restructured so that it becomes a submenu item.