### PR TITLE
PLANET-3347: #375896 having multiple carousels in a post some may seem unresponsive to manual scroll

### DIFF
--- a/classes/controller/blocks/class-carousel-controller.php
+++ b/classes/controller/blocks/class-carousel-controller.php
@@ -149,7 +149,7 @@ if ( ! class_exists( 'Carousel_Controller' ) ) {
 			}
 
 			$carousel_title = ( isset( $fields['carousel_block_title'] ) && ! empty( $fields['carousel_block_title'] ) ) ? $fields['carousel_block_title'] : '';
-			$carousel_id    = $this->generate_hash( $carousel_title, $images_dimensions );
+			$carousel_id    = 'gallery_' . uniqid();
 
 			$data = [
 				'id'     => $carousel_id,
@@ -158,21 +158,6 @@ if ( ! class_exists( 'Carousel_Controller' ) ) {
 			];
 
 			return $data;
-		}
-
-		/**
-		 * Create a short hash to be used as the carousel's dom id.
-		 *
-		 * @param string $title      Carousel's title.
-		 * @param array  $dimensions Dimensions of carousel's images.
-		 *
-		 * @return string A string that will be the carousel's id.
-		 */
-		private function generate_hash( $title, $dimensions ) {
-			$temp_string      = $title . '_' . implode( '_', $dimensions );
-			$carousel_id_hash = hash( 'crc32', $temp_string );
-
-			return 'carousel_' . $carousel_id_hash;
 		}
 	}
 }

--- a/classes/controller/blocks/class-gallery-controller.php
+++ b/classes/controller/blocks/class-gallery-controller.php
@@ -196,7 +196,7 @@ if ( ! class_exists( 'Gallery_Controller' ) ) {
 				$images[] = $image_data;
 			}
 
-			$gallery_id = $this->generate_hash( $gallery_title, $images_dimensions );
+			$gallery_id = 'gallery_' . uniqid();
 
 			$data = [
 				'id'          => $gallery_id,
@@ -207,21 +207,6 @@ if ( ! class_exists( 'Gallery_Controller' ) ) {
 			];
 
 			return $data;
-		}
-
-		/**
-		 * Create a short hash to be used as the carousel's dom id.
-		 *
-		 * @param string $title      Gallery's title.
-		 * @param array  $dimensions Dimensions of gallery's images.
-		 *
-		 * @return string A string that will be the carousel's id.
-		 */
-		private function generate_hash( $title, $dimensions ) {
-			$temp_string     = $title . '_' . implode( '_', $dimensions );
-			$gallery_id_hash = hash( 'crc32', $temp_string );
-
-			return 'gallery_' . $gallery_id_hash;
 		}
 	}
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-3347

A bit of context: there was a function for generating a hash for the carousel/gallery (depending on the block version), which was based on title + image dimensions. As the title may be absent and the image dimensions may be the same for two galleries (specially since images are normalized and cropped), looks like there is no need to base the hash on those two parameters. I replaced the function with `uniqid`. These hashes are only needed for the DOM.