### PR TITLE
PLANET-3506 The wp object $action that we use already has the excerpt

### DIFF
--- a/classes/controller/blocks/class-covers-controller.php
+++ b/classes/controller/blocks/class-covers-controller.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'Covers_Controller' ) ) {
 					$covers[] = [
 						'tags'        => $tags,
 						'title'       => get_the_title( $action ),
-						'excerpt'     => get_the_excerpt( $action ),    // Note: WordPress removes shortcodes from auto-generated excerpts.
+						'excerpt'     => $action->post_excerpt,
 						'image'       => get_the_post_thumbnail_url( $action, 'large' ),
 						'button_text' => $cover_button_text,
 						'button_link' => get_permalink( $action->ID ),

--- a/classes/controller/blocks/class-newcovers-controller.php
+++ b/classes/controller/blocks/class-newcovers-controller.php
@@ -466,8 +466,7 @@ if ( ! class_exists( 'NewCovers_Controller' ) ) {
 					$covers[] = [
 						'tags'        => $tags,
 						'title'       => get_the_title( $action ),
-						'excerpt'     => get_the_excerpt( $action ),
-						// Note: WordPress removes shortcodes from auto-generated excerpts.
+						'excerpt'     => $action->post_excerpt,
 						'image'       => get_the_post_thumbnail_url( $action, 'large' ),
 						'button_text' => $cover_button_text,
 						'button_link' => get_permalink( $action->ID ),


### PR DESCRIPTION
Fixes https://github.com/greenpeace/planet4-plugin-blocks/issues/544
Where in php7.2 the get_the_excerpt is called from outside the loop, it throws the error reported in the [Jira ticket](https://jira.greenpeace.org/browse/PLANET-3506). 

Since we have already loaded the whole post (which is saved in the $action as a wp object), and it already has the parameter post_excerpt in it, we don't need to call a separate function to retrieve it. 

