### PR TITLE
PLANET-3508 - Remove button class from Split Two Column CTA

### DIFF
--- a/includes/blocks/split_two_columns.twig
+++ b/includes/blocks/split_two_columns.twig
@@ -32,7 +32,7 @@
 					<p class="split-two-column-item-subtitle">{{ issue.description|truncate(25, true)|raw }}</p>
 				{% endif %}
 				{% if ( issue.link_text and issue.link_url ) %}
-					<a class="split-two-column-item-link btn-secondary" href="{{ issue.link_url }}">{{ issue.link_text }}</a>
+					<a class="split-two-column-item-link" href="{{ issue.link_url }}">{{ issue.link_text }}</a>
 				{% endif %}
 			</div>
 		</div>


### PR DESCRIPTION
This reverts commit 384514aeca2ed06fb3aae9c517ae90de91baa203.

Not sure why this change happened initially. @pablocubico maybe you have some insight? 