### PR TITLE
Add local testing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 
-vendor/*
-!vendor/composer
-!vendor/autoload.php
-yarn-error.log
+vendor
 node_modules/
 
 # Translation backups #

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,8 @@
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.3.2",
     "wp-coding-standards/wpcs": "^1.1.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.0",
+    "stevegrunwell/phpunit-markup-assertions": "^1.2",
     "phpunit/phpunit": "^6.2"
   },
   "require": {}


### PR DESCRIPTION
Now that no longer have vendor files in the repo, it's safe to add the same dev dependencies we have on master-theme.

Updated the gitignore to ignore all generated vendor files.