### PR TITLE
PLANET-1884 Fixed campaign referencing same focus as issue.

### DIFF
--- a/includes/blocks/split_two_columns.twig
+++ b/includes/blocks/split_two_columns.twig
@@ -42,7 +42,7 @@
 					<div class="split-two-column-item-image">
 						<img src="{{ campaign.image }}"
 							 srcset="{{ campaign.srcset }}"
-							 alt="{{ campaign.image_alt }}" style="object-position: {{ issue.focus }};">
+							 alt="{{ campaign.image_alt }}" style="object-position: {{ campaign.focus }};">
 					</div>
 				{% else %}
 					<div class="split-two-column-item-image">


### PR DESCRIPTION
- Initial PR was erroneously applying the issues image focus to both the issues image and the campaigns image.
- Changed to apply campaign image focus to campaign image