### PR TITLE
Planet-3565 Counter block - Use API if API is given

### DIFF
--- a/classes/controller/blocks/class-counter-controller.php
+++ b/classes/controller/blocks/class-counter-controller.php
@@ -56,6 +56,15 @@ if ( ! class_exists( 'Counter_Controller' ) ) {
 					],
 				],
 				[
+					'label' => __( 'Completed API URL', 'planet4-blocks-backend' ),
+					'attr'  => 'completed_api',
+					'type'  => 'url',
+					'meta'  => [
+						'placeholder' => __( 'API URL of completed number. If filled in will overide the "Completed" field', 'planet4-blocks-backend' ),
+						'data-plugin' => 'planet4-blocks',
+					],
+				],
+				[
 					'label' => __( 'Target', 'planet4-blocks-backend' ),
 					'attr'  => 'target',
 					'type'  => 'number',
@@ -98,11 +107,24 @@ if ( ! class_exists( 'Counter_Controller' ) ) {
 		 * @return array The data to be passed in the View.
 		 */
 		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
-			$completed = floatval( $fields['completed'] );
-			$target    = floatval( $fields['target'] );
 
-			$fields['percent'] = $target > 0 ? round( $completed / $target * 100 ) : 0;
-			$fields['text']    = str_replace(
+			$completed = 0;
+			if ( array_key_exists( 'completed', $fields ) ) {
+				$completed = floatval( $fields['completed'] );
+			}
+			$target = floatval( $fields['target'] );
+
+			if ( array_key_exists( 'completed_api', $fields ) ) {
+				$response_api  = wp_remote_get( $fields['completed_api'] );
+				$response_body = json_decode( $response_api['body'], true );
+				if ( is_array( $response_body ) && array_key_exists( 'unique_count', $response_body ) && is_int( $response_body['unique_count'] ) ) {
+					$completed = floatval( $response_body['unique_count'] );
+				}
+			}
+
+			$fields['completed'] = $completed;
+			$fields['percent']   = $target > 0 ? round( $completed / $target * 100 ) : 0;
+			$fields['text']      = str_replace(
 				// Note: something seems to strip out sensible delimiters like {}, <>, [] and $$ in the WYSIWYG.
 				[ '%completed%', '%target%', '%remaining%' ],
 				[ number_format( $completed ), number_format( $target ), number_format( $target - $completed ) ],

--- a/tests/unit/test-counter.php
+++ b/tests/unit/test-counter.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'P4_CounterTest' ) ) {
 			];
 			$data   = $this->block->prepare_data( $fields, '', '' );
 
-			$this->assertEquals( '', $data['fields']['completed'] );
+			$this->assertEquals( 0, $data['fields']['completed'] );
 			$this->assertEquals( '', $data['fields']['target'] );
 			$this->assertEquals( 0, $data['fields']['percent'] );
 		}


### PR DESCRIPTION
[Jira issue: PLANET-3565](https://jira.greenpeace.org/browse/PLANET-3565)
Added functionality that allows editors to define an API URL from the global counter application. 
If such a url is added, AND it returns a valid Json, with a field named "unique_count" AND the value is an integer, then the manual "completed" field is overwritten by the one returned by the API. 

To test it: Create a new counter block, and add the url that is defined in the description of the Jira ticket. 