### PR TITLE
PLANET-3565 use wp_safe_remote_get instead of wp_remote_get

### DIFF
--- a/classes/controller/blocks/class-counter-controller.php
+++ b/classes/controller/blocks/class-counter-controller.php
@@ -115,7 +115,7 @@ if ( ! class_exists( 'Counter_Controller' ) ) {
 			$target = floatval( $fields['target'] );
 
 			if ( array_key_exists( 'completed_api', $fields ) ) {
-				$response_api  = wp_remote_get( $fields['completed_api'] );
+				$response_api  = wp_safe_remote_get( $fields['completed_api'] );
 				$response_body = json_decode( $response_api['body'], true );
 				if ( is_array( $response_body ) && array_key_exists( 'unique_count', $response_body ) && is_int( $response_body['unique_count'] ) ) {
 					$completed = floatval( $response_body['unique_count'] );


### PR DESCRIPTION
As per feedback on https://github.com/greenpeace/planet4-plugin-blocks/pull/562