### PR TITLE
PLANET-3567 - Add class names for tags to article list items

### DIFF
--- a/includes/teasers/tease-articles.twig
+++ b/includes/teasers/tease-articles.twig
@@ -1,4 +1,4 @@
-<article class="article-list-item" >
+<article class="article-list-item{% for tag in recent_post.tags %} tag-{{ tag.name|e('wp_kses_post')|lower }}{% endfor %}" >
 	{% if recent_post.thumbnail_ratio < 1 %}
 		<div class="article-list-item-image">
 			<div class="article-image-holder">


### PR DESCRIPTION
Enables css styling of articles depending on the article's tags.

Opted to put the code on one line to prevent additional space characters in the output.