### PR TITLE
PLANET-3566 Add to the plugins report  which tags are use redirection

### DIFF
--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -115,6 +115,42 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				echo '<br>';
 			}
 
+
+			// Add to the report a breakdown of which tags are using a redirect page and which do not
+			// The first query shows the ones that do not use a redirect page
+			$sql     = "SELECT term.name, tm.meta_value, tt.term_id
+						FROM " . $wpdb->prefix . "term_taxonomy AS tt, " . $wpdb->prefix . "terms AS term, " . $wpdb->prefix . "termmeta AS tm
+						WHERE tt.`taxonomy`='post_tag' 
+						AND term.term_id = tt.term_id
+						AND tm.term_id=tt.term_id
+						AND tm.meta_key='redirect_page'
+						AND tm.meta_value =''";
+			$results = $wpdb->get_results( $sql );
+			echo '<hr>';
+			echo '<h2>Tags without redirection page</h2>';
+			foreach ( $results as $result ) {
+				echo '<a href="term.php?taxonomy=post_tag&tag_ID=' . $result->term_id . '" >' . $result->name . '</a>';
+				echo '<br>';
+			}
+
+			// Add to the report a breakdown of which tags are using a redirect page and which do not
+			// The second query shows the ones that do use a redirect page
+			$sql     = "SELECT term.name, tm.meta_value, tt.term_id
+						FROM " . $wpdb->prefix . "term_taxonomy AS tt, " . $wpdb->prefix . "terms AS term, " . $wpdb->prefix . "termmeta AS tm
+						WHERE tt.`taxonomy`='post_tag' 
+						AND term.term_id = tt.term_id
+						AND tm.term_id=tt.term_id
+						AND tm.meta_key='redirect_page'
+						AND tm.meta_value !=''";
+			$results = $wpdb->get_results( $sql );
+			echo '<hr>';
+			echo '<h2>Tags that use a redirection page</h2>';
+			foreach ( $results as $result ) {
+				echo '<a href="term.php?taxonomy=post_tag&tag_ID=' . $result->term_id . '" >' . $result->name . '</a>';
+				echo '<br>';
+			}
+
+
 			// phpcs:enable
 		}
 

--- a/planet4-blocks.php
+++ b/planet4-blocks.php
@@ -189,6 +189,28 @@ function plugin_blocks_report_json() {
 		$cnt = $wpdb->get_var( $sql );
 		$report['CarouselHeader-Full-Width-Classic'] = $cnt;
 
+		// Add to the report a breakdown of which tags are using redirect to page and which not part 1
+		$sql = "SELECT count(tt.term_id) AS cnt
+				FROM " . $wpdb->prefix . "term_taxonomy AS tt, " . $wpdb->prefix . "terms AS term, " . $wpdb->prefix . "termmeta AS tm
+				WHERE tt.`taxonomy`='post_tag' 
+				AND term.term_id = tt.term_id
+				AND tm.term_id=tt.term_id
+				AND tm.meta_key='redirect_page'
+				AND tm.meta_value !=''";
+		$cnt = $wpdb->get_var( $sql );
+		$report['TagsUsingRedirectionPage'] = $cnt;
+
+		// Add to the report a breakdown of which tags are using redirect to page and which not part 2
+		$sql = "SELECT count(tt.term_id) AS cnt
+				FROM " . $wpdb->prefix . "term_taxonomy AS tt, " . $wpdb->prefix . "terms AS term, " . $wpdb->prefix . "termmeta AS tm
+				WHERE tt.`taxonomy`='post_tag' 
+				AND term.term_id = tt.term_id
+				AND tm.term_id=tt.term_id
+				AND tm.meta_key='redirect_page'
+				AND tm.meta_value =''";
+		$cnt = $wpdb->get_var( $sql );
+		$report['TagsNotUsingRedirectionPage'] = $cnt;
+
 		wp_cache_add( $cache_key, $report, '', 3600 );
 
 	}


### PR DESCRIPTION
[JIRA ticket](https://jira.greenpeace.org/browse/PLANET-3566)
Add to the plugins report with a breakdown which tags are use redirection and which do not. 
Add it to both the report in the backend, and the json exported. 
While this funcionality (tags with redirection) is not part of the plugins block but of the master theme, we add it to the plugins report, because it is already exporting data to the external place we want to report to.

Note: After all NROs/sites have switched all their tag pages to redirect instead of auto generation, we will retire the functionality for redirection, and we will then retire this part of the report as well.

You can demo the functionality 
a) By seeing the report in the Backend -> Blocks -> usage menu
![3566-tags-redirection](https://user-images.githubusercontent.com/2528229/58313566-89ee8000-7e16-11e9-98bc-f02af7728dfa.png)

b) by going to the url /wp-json/plugin_blocks/v1/plugin_blocks_report/  on your site and checking the `TagsUsingRedirectionPage` and `TagsNotUsingRedirectionPage` values 