### PR TITLE
PLANET-3566 Fix report for tags that do not use redirection

### DIFF
--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -118,13 +118,32 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 
 			// Add to the report a breakdown of which tags are using a redirect page and which do not
 			// The first query shows the ones that do not use a redirect page
-			$sql     = "SELECT term.name, tm.meta_value, tt.term_id
-						FROM " . $wpdb->prefix . "term_taxonomy AS tt, " . $wpdb->prefix . "terms AS term, " . $wpdb->prefix . "termmeta AS tm
-						WHERE tt.`taxonomy`='post_tag' 
-						AND term.term_id = tt.term_id
-						AND tm.term_id=tt.term_id
-						AND tm.meta_key='redirect_page'
-						AND tm.meta_value =''";
+			$sql = "( SELECT term.name, tt.term_id 
+							FROM " . $wpdb->prefix . "term_taxonomy AS tt, 
+							" . $wpdb->prefix . "terms AS term, 
+							" . $wpdb->prefix . "termmeta AS tm 
+							WHERE tt.`taxonomy`='post_tag' 
+							AND term.term_id = tt.term_id 
+							AND tm.term_id=tt.term_id 
+							AND tm.meta_key='redirect_page' 
+							AND tm.meta_value ='' )
+						UNION 
+						( SELECT term.name, tt.term_id 
+							FROM " . $wpdb->prefix . "term_taxonomy AS tt, 
+							" . $wpdb->prefix . "terms AS term, 
+							" . $wpdb->prefix . "termmeta AS tm
+							WHERE tt.`taxonomy`='post_tag' 
+							AND term.term_id = tt.term_id 
+							AND tm.term_id=tt.term_id 
+							AND tm.term_id NOT IN (SELECT tt.term_id 
+													FROM " . $wpdb->prefix . "term_taxonomy AS tt, 
+													" . $wpdb->prefix . "terms AS term, 
+													" . $wpdb->prefix . "termmeta AS tm 
+													WHERE tt.`taxonomy`='post_tag' 
+													AND term.term_id = tt.term_id 
+													AND tm.term_id=tt.term_id 
+													AND tm.meta_key='redirect_page')
+							GROUP BY term.name, tt.term_id )";
 			$results = $wpdb->get_results( $sql );
 			echo '<hr>';
 			echo '<h2>Tags without redirection page</h2>';


### PR DESCRIPTION
Related previous PR: https://github.com/greenpeace/planet4-plugin-blocks/pull/568
The functionality does not change, but gets fixed. 
Make a double (Union) query to include also the tags that do not have a `redirect_page` meta_key
Before, it was working only for tags that had been saved once after the meta_key has been introduced

