### PR TITLE
PLANET-3841: Columns block: font (and size) changing when adding paragraph in block descriptions

### DIFF
--- a/includes/blocks/articles.twig
+++ b/includes/blocks/articles.twig
@@ -9,7 +9,7 @@
 					</header>
 				{% endif %}
 				{% if ( fields.articles_description ) %}
-					<p class="page-section-description">{{ fields.articles_description|e('wp_kses_post')|raw }}</p>
+					<div class="page-section-description">{{ fields.articles_description|e('wp_kses_post')|raw }}</div>
 				{% endif %}
 
 				<div class="article-list-section clearfix">

--- a/includes/blocks/campaign_thumbnail.twig
+++ b/includes/blocks/campaign_thumbnail.twig
@@ -22,7 +22,7 @@
 				{% endif %}
 
 				{% if ( fields.description ) %}
-					<p class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</p>
+					<div class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</div>
 				{% endif %}
 
 				<div class="thumbnail-largeview-container limit-visibility">

--- a/includes/blocks/columns.twig
+++ b/includes/blocks/columns.twig
@@ -11,7 +11,7 @@
 						</header>
 					{% endif %}
 					{% if ( fields.columns_description ) %}
-						<p class="page-section-description">{{ fields.columns_description|e('wp_kses_post')|raw }}</p>
+						<div class="page-section-description">{{ fields.columns_description|e('wp_kses_post')|raw }}</div>
 					{% endif %}
 
 					<div class="row">

--- a/includes/blocks/columns_tasks.twig
+++ b/includes/blocks/columns_tasks.twig
@@ -10,7 +10,7 @@
 					</header>
 				{% endif %}
 				{% if ( fields['columns_description'] ) %}
-					<p class="page-section-description">{{ fields['columns_description']|e('wp_kses_post')|raw }}</p>
+					<div class="page-section-description">{{ fields['columns_description']|e('wp_kses_post')|raw }}</div>
 				{% endif %}
 
 				<div class="tasks-wrap can-do-steps d-none d-lg-block">

--- a/includes/blocks/content_four_column.twig
+++ b/includes/blocks/content_four_column.twig
@@ -17,7 +17,7 @@
 				{% endif %}
 
 				{% if (description) %}
-					<p class="page-section-description">{{ description|e('wp_kses_post')|raw }}</p>
+					<div class="page-section-description">{{ description|e('wp_kses_post')|raw }}</div>
 				{% endif %}
 
 				<div class="row publications-slider limit-visibility">

--- a/includes/blocks/content_three_column.twig
+++ b/includes/blocks/content_three_column.twig
@@ -8,7 +8,7 @@
 					</header>
 				{% endif %}
 				{% if ( fields.description ) %}
-					<p class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</p>
+					<div class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</div>
 				{% endif %}
 
 				<div class="three-column-images row">

--- a/includes/blocks/cookies.twig
+++ b/includes/blocks/cookies.twig
@@ -8,7 +8,7 @@
 				</header>
 			{% endif %}
 			{% if ( data.description ) %}
-				<p class="page-section-description">{{ data.description }}</p>
+				<div class="page-section-description">{{ data.description }}</div>
 			{% endif %}
 			{% if ( data.necessary_cookies_name and data.necessary_cookies_description ) %}
 				<label class="custom-control custom-checkbox">

--- a/includes/blocks/counter.twig
+++ b/includes/blocks/counter.twig
@@ -8,7 +8,7 @@
                     </header>
                 {% endif %}
                 {% if ( fields.description ) %}
-                    <p class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</p>
+                    <div class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</div>
                 {% endif %}
             </div>
             <div class="content-counter">

--- a/includes/blocks/covers.twig
+++ b/includes/blocks/covers.twig
@@ -18,7 +18,7 @@
 					</header>
 				{% endif %}
 				{% if ( fields.description ) %}
-					<p class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</p>
+					<div class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</div>
 				{% endif %}
 
 				<div class="row limit-visibility">

--- a/includes/blocks/gallery.twig
+++ b/includes/blocks/gallery.twig
@@ -14,7 +14,7 @@
 					{% endif %}
 
 					{% if ( description ) %}
-						<p class="page-section-description">{{ description|e('wp_kses_post')|raw }}</p>
+						<div class="page-section-description">{{ description|e('wp_kses_post')|raw }}</div>
 					{% endif %}
 
 					{% if images|length > 1 %}
@@ -82,7 +82,7 @@
 					{% endif %}
 
 					{% if ( description ) %}
-						<p class="page-section-description">{{ description|e('wp_kses_post')|raw }}</p>
+						<div class="page-section-description">{{ description|e('wp_kses_post')|raw }}</div>
 					{% endif %}
 
 					<div class="three-column-images row">
@@ -116,7 +116,7 @@
 					{% endif %}
 
 					{% if ( description ) %}
-						<p class="page-section-description">{{ description|e('wp_kses_post')|raw }}</p>
+						<div class="page-section-description">{{ description|e('wp_kses_post')|raw }}</div>
 					{% endif %}
 				{% endif %}
 

--- a/includes/blocks/media_video.twig
+++ b/includes/blocks/media_video.twig
@@ -7,7 +7,7 @@
 				</header>
 			{% endif %}
 			{% if ( fields.description ) %}
-				<p class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</p>
+				<div class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</div>
 			{% endif %}
 			<div class="{{ fields.type }}-embed">
 				{% if fields.embed_html %}

--- a/includes/blocks/social_media.twig
+++ b/includes/blocks/social_media.twig
@@ -6,7 +6,7 @@
 			</header>
 		{% endif %}
 		{% if ( description ) %}
-			<p class="page-section-description">{{ description|e('wp_kses_post')|raw }}</p>
+			<div class="page-section-description">{{ description|e('wp_kses_post')|raw }}</div>
 		{% endif %}
 
 		<div class="social-media-embed {{ alignment_class }}">

--- a/includes/blocks/subheader.twig
+++ b/includes/blocks/subheader.twig
@@ -8,7 +8,7 @@
 					</header>
 				{% endif %}
                 {% if ( fields.description ) %}
-					<p class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</p>
+					<div class="page-section-description">{{ fields.description|e('wp_kses_post')|raw }}</div>
                 {% endif %}
 			</div>
 		</section>

--- a/includes/blocks/tasks.twig
+++ b/includes/blocks/tasks.twig
@@ -11,7 +11,7 @@
 				{% endif %}
 				<div class="row">
 					{% if ( fields.tasks_description ) %}
-						<p class="page-section-description">{{ fields.tasks_description|e('wp_kses_post')|raw }}</p>
+						<div class="page-section-description">{{ fields.tasks_description|e('wp_kses_post')|raw }}</div>
 					{% endif %}
 				</div>
 

--- a/includes/blocks/timeline.twig
+++ b/includes/blocks/timeline.twig
@@ -6,7 +6,7 @@
 			</header>
 		{% endif %}
 		{% if ( description ) %}
-			<p class="page-section-description">{{ description|e('wp_kses_post')|raw }}</p>
+			<div class="page-section-description">{{ description|e('wp_kses_post')|raw }}</div>
 		{% endif %}
 		<div id="{{ timeline_id }}"></div>
 	</section>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-3841

Note: the ticket is about the columns block, but this was happening in all blocks since the description can contain `<p>` paragraphs, but `<p>` elements apparently should not be nested according to: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p

This also needs a minor change in the styleguide: https://github.com/greenpeace/planet4-styleguide/pull/9


