### PR TITLE
Carousel Header: Use h1 as default option

### DIFF
--- a/classes/controller/blocks/class-carouselheader-controller.php
+++ b/classes/controller/blocks/class-carouselheader-controller.php
@@ -141,7 +141,6 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 						'attr'    => 'header_size_' . $i,
 						'type'    => 'select',
 						'options' => [
-							0    => __( ' - Select Text Size - ', 'planet4-blocks-backend' ),
 							'h1' => 'h1',
 							'h2' => 'h2',
 							'h3' => 'h3',
@@ -230,7 +229,7 @@ if ( ! class_exists( 'CarouselHeader_Controller' ) ) {
 				$temp_array      = [
 					"header_$i"      => $attributes[ "header_$i" ] ?? '',
 					"header_size_$i" => $attributes[ "header_size_$i" ] ?? '',
-					"subheader_$i"   => $attributes[ "subheader_$i" ] ?? '',
+					"subheader_$i"   => $attributes[ "subheader_$i" ] ?? 'h1',
 					"description_$i" => $attributes[ "description_$i" ] ?? '',
 					"image_$i"       => $attributes[ "image_$i" ] ?? '',
 					"focus_image_$i" => $attributes[ "focus_image_$i" ] ?? '',

--- a/includes/blocks/carousel_header_full-width-classic.twig
+++ b/includes/blocks/carousel_header_full-width-classic.twig
@@ -36,7 +36,7 @@
 										<div class="container main-header">
 											<div class="carousel-captions-wrapper">
 												{% if ( attribute( fields, 'header_' ~ i ) ) %}
-													<{{ fields['header_size_' ~ i] }}>{{ carouselTools.truncateChars( attribute( fields, 'header_' ~ i ), 32 ) }}</{{ fields['header_size_' ~ i] }}>
+													<{{ fields['header_size_' ~ i]|default('h1') }}>{{ carouselTools.truncateChars( attribute( fields, 'header_' ~ i ), 32 ) }}</{{ fields['header_size_' ~ i]|default('h1') }}>
 												{% endif %}
 												{% if ( attribute( fields, 'description_' ~ i )  ) %}
 													<p>{{ carouselTools.truncateChars( attribute( fields, 'description_' ~ i ), 200 ) }}</p>

--- a/includes/blocks/carousel_header_zoom-and-slide-to-gray.twig
+++ b/includes/blocks/carousel_header_zoom-and-slide-to-gray.twig
@@ -24,7 +24,7 @@
 						<div class="carousel-caption">
 							<div class="container main-header">
 								{% if ( attribute( fields, 'header_'~i ) ) %}
-									<h1>{{ attribute( fields, 'header_'~i ) }}</h1>
+									<{{ fields['header_size_' ~ i]|default('h1') }}>{{ attribute( fields, 'header_'~i ) }}</{{ fields['header_size_' ~ i]|default('h1') }}>
 								{% endif %}
 								{% if ( attribute( fields, 'subheader_'~i ) and fields.block_style != 'full-width-classic' ) %}
 									<h2>{{ attribute( fields, 'subheader_'~i ) }}</h2>


### PR DESCRIPTION
After the change introduced at 18b53a6e15af3da98b2df5e81ec36882e29bfea3 there was no default heading and that breaks existing instances of Carousel Header.