### PR TITLE
PLANET-3892 Use a larger image size when more than one column is set

### DIFF
--- a/classes/controller/blocks/class-columns-controller.php
+++ b/classes/controller/blocks/class-columns-controller.php
@@ -230,9 +230,7 @@ if ( ! class_exists( 'Columns_Controller' ) ) {
 			if ( static::LAYOUT_NO_IMAGE !== $columns_block_style ) {
 
 				if ( static::LAYOUT_TASKS === $columns_block_style || static::LAYOUT_IMAGES === $columns_block_style ) {
-					if ( $columns_set >= 3 ) {
-						$image_size = 'medium';
-					} elseif ( 2 === $columns_set ) {
+					if ( $columns_set >= 2 ) {
 						$image_size = 'articles-medium-large';
 					} else {
 						$image_size = 'large';


### PR DESCRIPTION
Use articles-medium-large image size in columns block for more than 1 column set.

---
Wide screen medium image size thumbnail
![columns_wide_screen_medium_thumbnail](https://user-images.githubusercontent.com/15197444/62772396-1b7d9d80-baa8-11e9-80de-9672975daba5.png)

---
Wide screen articles-medium-large image size thumbnail
![columns_wide_screen_articles-medium-large_thumbnail](https://user-images.githubusercontent.com/15197444/62772404-21737e80-baa8-11e9-8684-923e56eda89e.png)

---
Small screen medium image size thumbnail
![columns_medium_thumbnail](https://user-images.githubusercontent.com/15197444/62772410-26383280-baa8-11e9-9cd9-c12aa013f730.png)

---
Small screen articles-medium-large image size thumbnail
![columns_articles-medium-large_thumbnail](https://user-images.githubusercontent.com/15197444/62772419-2d5f4080-baa8-11e9-884f-0ca17c2bfe46.png)
