### PR TITLE
Fix stylelint and eslint paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,11 @@ job-references:
       - run:
           name: "stylelint"
           when: always
-          command: stylelint $HOME/project/assets/scss/**/*.scss $HOME/project/assets/css/*.css $HOME/project/admin/css/*.css $HOME/project/admin/scss/*.scss
+          command: stylelint "$HOME/project/assets/scss/**/*.scss" "$HOME/project/admin/css/*.css" "$HOME/project/admin/scss/*.scss"
       - run:
           name: "eslint"
           when: always
-          command: eslint $HOME/project/assets/js/**/*.js $HOME/project/admin/js/blocks/*.js
+          command: eslint "$HOME/project/assets/js/**/*.js" "$HOME/project/admin/js/blocks/*.js"
       - store_test_results:
           path: /tmp/test-results
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ const path_style = 'assets/scss/style.scss';
 
 const path_admin_dest = './admin/';
 const path_scss_admin = './admin/scss/**/*.scss';
+const path_css_admin = './admin/css/**/*.css';
 const path_style_admin = './admin/scss/blocks-admin.scss';
 
 const blocks_javascripts = [
@@ -40,7 +41,7 @@ let error_handler = {
 };
 
 function lint_css() {
-  return gulp.src([path_scss, path_scss_admin])
+  return gulp.src([path_scss, path_scss_admin, path_css_admin])
     .pipe(plumber(error_handler))
     .pipe(stylelint({
       reporters: [{ formatter: 'string', console: true}]


### PR DESCRIPTION
Double asterisk patterns need double quotes to work properly.