### PR TITLE
PLANET-4000 Enhance shortcode replacer to query for posts from all languages

### DIFF
--- a/classes/command/class-shortcodereplacer.php
+++ b/classes/command/class-shortcodereplacer.php
@@ -62,6 +62,12 @@ class ShortcodeReplacer {
 			'nopaging'    => true,
 		];
 
+		// If wpml plugin is installed and activated enable suppress filters,
+		// so we can retrieve posts for all languages.
+		if ( function_exists( 'icl_object_id' ) ) {
+			$args['suppress_filters'] = true;
+		}
+
 		if ( $post_id ) {
 			$args['p'] = $post_id;
 		}


### PR DESCRIPTION
Add suppress_filters arg in shortcode replacer to retrieve posts from all languages when WPML is detected.